### PR TITLE
Enable passing arbitrary environment variables & secrets to re-usable workflow

### DIFF
--- a/.github/workflows/scripted-build-pipeline.yml
+++ b/.github/workflows/scripted-build-pipeline.yml
@@ -77,7 +77,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/env-var-support
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
       with: 
         environmentVariablesJsonBase64: ${{ inputs.compilePhaseEnv}}
         secretsJsonBase64: ${{ inputs.compilePhaseSecrets}}
@@ -109,7 +109,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/env-var-support
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
       with: 
         environmentVariablesJsonBase64: ${{ inputs.testPhaseEnv}}
         secretsJsonBase64: ${{ inputs.testPhaseSecrets}}
@@ -187,7 +187,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/env-var-support
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
       with: 
         environmentVariablesJsonBase64: ${{ inputs.packagePhaseEnv}}
         secretsJsonBase64: ${{ inputs.packagePhaseSecrets}}
@@ -224,7 +224,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/env-var-support
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
       with: 
         environmentVariablesJsonBase64: ${{ inputs.publishPhaseEnv}}
         secretsJsonBase64: ${{ inputs.publishPhaseSecrets}}

--- a/.github/workflows/scripted-build-pipeline.yml
+++ b/.github/workflows/scripted-build-pipeline.yml
@@ -95,7 +95,7 @@ jobs:
     
     - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/env-var-support
       with: 
-        environmentVariablesJson: ${{ inputs.testPhaseEnv}}
+        environmentVariablesJsonBase64: ${{ inputs.testPhaseEnv}}
         secretsJsonBase64: ${{ inputs.testPhaseSecrets}}
     - run: |
         Get-Content -Raw $env:GITHUB_ENV

--- a/.github/workflows/scripted-build-pipeline.yml
+++ b/.github/workflows/scripted-build-pipeline.yml
@@ -25,6 +25,10 @@ on:
         required: false
         default: '{}'
         type: string
+      compilePhaseSecrets:
+        description: A Base64-encoded JSON object representing the secrets required when running the 'copmile' stage of this workflow.
+        required: false
+        type: string        
       testPhaseEnv:
         description: A JSON object representing the environment variables required when running the 'test' stage of this workflow.
         required: false
@@ -38,11 +42,19 @@ on:
         required: false
         default: '{}'
         type: string
+      packagePhaseSecrets:
+        description: A Base64-encoded JSON object representing the secrets required when running the 'package' stage of this workflow.
+        required: false
+        type: string        
       publishPhaseEnv:
         description: A JSON object representing the environment variables required when running the 'publish' stage of this workflow.
         required: false
         default: '{}'
         type: string
+      publishPhaseSecrets:
+        description: A Base64-encoded JSON object representing the secrets required when running the 'publish' stage of this workflow.
+        required: false
+        type: string        
       forcePublish:
         description: When true, the Publish stage will be run regardless of the current branch or tag.
         required: false
@@ -58,7 +70,6 @@ jobs:
   compile:
     name: Compile & Analyse
     runs-on: ubuntu-latest
-    env: ${{ fromJson(inputs.compilePhaseEnv) }}
     outputs:
       semver: ${{ steps.run_compile.outputs.semver }}
       major: ${{ steps.run_compile.outputs.major }}
@@ -69,6 +80,15 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/env-var-support
+      with: 
+        environmentVariablesJsonBase64: ${{ inputs.compilePhaseEnv}}
+        secretsJsonBase64: ${{ inputs.compilePhaseSecrets}}
+    - name: Debug Variables
+      if: env.ACTIONS_RUNNER_DEBUG == 'true'
+      run: |
+        gci env:/ | fl | out-string | Write-Host
+      shell: pwsh
     - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@main
       id: run_compile
       with:
@@ -92,16 +112,15 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    
     - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/env-var-support
       with: 
         environmentVariablesJsonBase64: ${{ inputs.testPhaseEnv}}
         secretsJsonBase64: ${{ inputs.testPhaseSecrets}}
-    - run: |
-        Get-Content -Raw $env:GITHUB_ENV
+    - name: Debug Variables
+      if: env.ACTIONS_RUNNER_DEBUG == 'true'
+      run: |
         gci env:/ | fl | out-string | Write-Host
       shell: pwsh
-
     - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@main
       with:
         displayName: Run Tests
@@ -167,11 +186,19 @@ jobs:
     - compile
     name: Package
     runs-on: ubuntu-latest
-    env: ${{ fromJson(inputs.packagePhaseEnv) }}
     steps:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/env-var-support
+      with: 
+        environmentVariablesJsonBase64: ${{ inputs.packagePhaseEnv}}
+        secretsJsonBase64: ${{ inputs.packagePhaseSecrets}}
+    - name: Debug Variables
+      if: env.ACTIONS_RUNNER_DEBUG == 'true'
+      run: |
+        gci env:/ | fl | out-string | Write-Host
+      shell: pwsh        
     - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@main
       with:
         displayName: Build Packages
@@ -196,11 +223,19 @@ jobs:
     name: Publish
     if: inputs.forcePublish || startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
-    env: ${{ fromJson(inputs.publishPhaseEnv) }}
     steps:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/env-var-support
+      with: 
+        environmentVariablesJsonBase64: ${{ inputs.publishPhaseEnv}}
+        secretsJsonBase64: ${{ inputs.publishPhaseSecrets}}
+    - name: Debug Variables
+      if: env.ACTIONS_RUNNER_DEBUG == 'true'
+      run: |
+        gci env:/ | fl | out-string | Write-Host
+      shell: pwsh        
     - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@main
       with:
         displayName: Publish Packages

--- a/.github/workflows/scripted-build-pipeline.yml
+++ b/.github/workflows/scripted-build-pipeline.yml
@@ -94,7 +94,7 @@ jobs:
         $envVarsJson = [System.Text.Encoding]::Unicode.GetString([Convert]::FromBase64String("${{ inputs.testPhaseEnv }}"))
         $envVars = ConvertFrom-Json -Depth 100 -AsHashtable $envVarsJson
         $envVars.Keys | % {
-          ('$_="{0}"' -f $envVars[$_]) | Out-File -Append -FilePath $env:GITHUB_ENV
+          ('{0}="{1}"' -f $_, $envVars[$_]) | Out-File -Append -FilePath $env:GITHUB_ENV
         }        
       shell: pwsh
     - run: |

--- a/.github/workflows/scripted-build-pipeline.yml
+++ b/.github/workflows/scripted-build-pipeline.yml
@@ -28,7 +28,10 @@ on:
       testPhaseEnv:
         description: A JSON object representing the environment variables required when running the 'test' stage of this workflow.
         required: false
-        default: '{}'
+        type: string
+      testPhaseSecrets:
+        description: A Base64-encoded JSON object representing the secrets required when running the 'test' stage of this workflow.
+        required: false
         type: string
       packagePhaseEnv:
         description: A JSON object representing the environment variables required when running the 'package' stage of this workflow.
@@ -89,18 +92,16 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - id: extractEnv
-      run: |
-        $envVarsJson = [System.Text.Encoding]::Unicode.GetString([Convert]::FromBase64String("${{ inputs.testPhaseEnv }}"))
-        $envVars = ConvertFrom-Json -Depth 100 -AsHashtable $envVarsJson
-        $envVars.Keys | % {
-          ('{0}={1}' -f $_, $envVars[$_]) | Out-File -Append -FilePath $env:GITHUB_ENV
-        }        
-      shell: pwsh
+    
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/env-var-support
+      with: 
+        environmentVariablesJson: ${{ inputs.testPhaseEnv}}
+        secretsJsonBase64: ${{ inputs.testPhaseSecrets}}
     - run: |
         Get-Content -Raw $env:GITHUB_ENV
         gci env:/ | fl | out-string | Write-Host
       shell: pwsh
+
     - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@main
       with:
         displayName: Run Tests

--- a/.github/workflows/scripted-build-pipeline.yml
+++ b/.github/workflows/scripted-build-pipeline.yml
@@ -23,7 +23,6 @@ on:
       compilePhaseEnv:
         description: A JSON object representing the environment variables required when running the 'compile' stage of this workflow.
         required: false
-        default: '{}'
         type: string
       compilePhaseSecrets:
         description: A Base64-encoded JSON object representing the secrets required when running the 'copmile' stage of this workflow.
@@ -40,7 +39,6 @@ on:
       packagePhaseEnv:
         description: A JSON object representing the environment variables required when running the 'package' stage of this workflow.
         required: false
-        default: '{}'
         type: string
       packagePhaseSecrets:
         description: A Base64-encoded JSON object representing the secrets required when running the 'package' stage of this workflow.
@@ -49,7 +47,6 @@ on:
       publishPhaseEnv:
         description: A JSON object representing the environment variables required when running the 'publish' stage of this workflow.
         required: false
-        default: '{}'
         type: string
       publishPhaseSecrets:
         description: A Base64-encoded JSON object representing the secrets required when running the 'publish' stage of this workflow.

--- a/.github/workflows/scripted-build-pipeline.yml
+++ b/.github/workflows/scripted-build-pipeline.yml
@@ -94,7 +94,7 @@ jobs:
         $envVarsJson = [System.Text.Encoding]::Unicode.GetString([Convert]::FromBase64String("${{ inputs.testPhaseEnv }}"))
         $envVars = ConvertFrom-Json -Depth 100 -AsHashtable $envVarsJson
         $envVars.Keys | % {
-          ('{0}="{1}"' -f $_, $envVars[$_]) | Out-File -Append -FilePath $env:GITHUB_ENV
+          ('{0}={1}' -f $_, $envVars[$_]) | Out-File -Append -FilePath $env:GITHUB_ENV
         }        
       shell: pwsh
     - run: |

--- a/.github/workflows/scripted-build-pipeline.yml
+++ b/.github/workflows/scripted-build-pipeline.yml
@@ -98,6 +98,7 @@ jobs:
         }        
       shell: pwsh
     - run: |
+        Get-Content -Raw $env:GITHUB_ENV
         gci env:/ | fl | out-string | Write-Host
       shell: pwsh
     - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@main

--- a/actions/prepare-env-vars-and-secrets/action.yml
+++ b/actions/prepare-env-vars-and-secrets/action.yml
@@ -21,7 +21,7 @@ runs:
   - id: prepareEnvVars
     name: Prepare Environment Variables
     run: |
-      Write-Host "REQUIRED_ENV_VARS: ${{ inputs.environmentVariablesJson }}"
+      # Write-Host "REQUIRED_ENV_VARS: ${{ inputs.environmentVariablesJson }}"
       $json = ConvertFrom-Json '${{ inputs.environmentVariablesJson }}' -Depth 100 | ConvertTo-Json -Depth 100 -Compress
       Write-Host "json: $json"
       $jsonb64 = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($json))
@@ -32,7 +32,7 @@ runs:
   - id: prepareSecrets
     name: Prepare Secrets
     run: |
-      Write-Host "REQUIRED_SECRETS: ${{ inputs.secretsJson }}"
+      # Write-Host "REQUIRED_SECRETS: ${{ inputs.secretsJson }}"
       $json = ConvertFrom-Json '${{ inputs.secretsJson }}' -Depth 100 | ConvertTo-Json -Depth 100 -Compress
       Write-Host "json: $json"
       $jsonb64 = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($json))

--- a/actions/prepare-env-vars-and-secrets/action.yml
+++ b/actions/prepare-env-vars-and-secrets/action.yml
@@ -1,0 +1,39 @@
+name: 'Endjin.RecommendedPractices.Build.SetEnvVarsAndSecret'
+description: 'Injects environment variables and secrets passed as JSON-formatted strings'
+inputs:
+  environmentVariablesJson:
+    description: A JSON object representing environment variables that need to be passed into the 'scripted-build-pipeline' re-usable workflow via its '*PhaseEnv' inputs.
+    default: '{}'
+  secretsJson:
+    description: A JSON object representing secrets that need to be passed into the 'scripted-build-pipeline' re-usable workflow via its '*PhaseSecrets' inputs.
+    default: '{}'
+outputs:
+  environmentVariablesJson:
+    description: JSON object representing environment variables that can be passed to the 'scripted-build-pipeline' re-usable workflow via its '*PhaseEnv' inputs.
+    value: ${{ steps.prepareEnvVars.outputs.RESOLVED_ENV_VARS }}
+  secretsBase64:
+    description: Base64-encoded JSON object representing secrets that can be passed to the 'scripted-build-pipeline' re-usable workflow via its '*PhaseSecrets' inputs.
+    value: ${{ steps.prepareSecrets.outputs.RESOLVED_SECRETS }}
+
+runs:
+  using: "composite"
+  steps:
+  - id: prepareEnvVars
+    name: Prepare Environment Variables
+    run: |
+      Write-Host "REQUIRED_ENV_VARS: ${{ inputs.environmentVariablesJson }}"
+      $json = ConvertFrom-Json '${{ inputs.environmentVariablesJson }}' -Depth 100 | ConvertTo-Json -Depth 100 -Compress
+      Write-Host "json: $json"
+      ("RESOLVED_ENV_VARS={0}" -f $json) | Out-File -Append $env:GITHUB_OUTPUT
+    shell: pwsh
+
+  - id: prepareSecrets
+    name: Prepare Secrets
+    run: |
+      Write-Host "REQUIRED_SECRETS: ${{ inputs.secretsJson }}"
+      $json = ConvertFrom-Json '${{ inputs.secretsJson }}' -Depth 100 | ConvertTo-Json -Depth 100 -Compress
+      Write-Host "json: $json"
+      $jsonb64 = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($json))
+      Write-Host "jsonb64: $jsonb64"
+      ("RESOLVED_SECRETS={0}" -f $jsonb64) | Out-File -Append $env:GITHUB_OUTPUT
+    shell: pwsh

--- a/actions/prepare-env-vars-and-secrets/action.yml
+++ b/actions/prepare-env-vars-and-secrets/action.yml
@@ -21,8 +21,11 @@ runs:
   - id: prepareEnvVars
     name: Prepare Environment Variables
     run: |
-      # Write-Host "REQUIRED_ENV_VARS: ${{ inputs.environmentVariablesJson }}"
-      $json = ConvertFrom-Json '${{ inputs.environmentVariablesJson }}' -Depth 100 | ConvertTo-Json -Depth 100 -Compress
+      $srcEnvVars = @'
+      ${{ inputs.environmentVariablesJson }}
+      '@
+      Write-Host "REQUIRED_ENV_VARS: $srcEnvVars"
+      $json = ConvertFrom-Json $srcEnvVars -Depth 100 | ConvertTo-Json -Depth 100 -Compress
       Write-Host "json: $json"
       $jsonb64 = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($json))
       Write-Host "jsonb64: $jsonb64"
@@ -32,8 +35,11 @@ runs:
   - id: prepareSecrets
     name: Prepare Secrets
     run: |
-      # Write-Host "REQUIRED_SECRETS: ${{ inputs.secretsJson }}"
-      $json = ConvertFrom-Json '${{ inputs.secretsJson }}' -Depth 100 | ConvertTo-Json -Depth 100 -Compress
+      $srcSecrets = @'
+      ${{ inputs.secretsJson }}
+      '@
+      Write-Host "REQUIRED_SECRETS: $srcSecrets"
+      $json = ConvertFrom-Json $srcSecrets -Depth 100 | ConvertTo-Json -Depth 100 -Compress
       Write-Host "json: $json"
       $jsonb64 = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($json))
       Write-Host "jsonb64: $jsonb64"

--- a/actions/prepare-env-vars-and-secrets/action.yml
+++ b/actions/prepare-env-vars-and-secrets/action.yml
@@ -8,10 +8,10 @@ inputs:
     description: A JSON object representing secrets that need to be passed into the 'scripted-build-pipeline' re-usable workflow via its '*PhaseSecrets' inputs.
     default: '{}'
 outputs:
-  environmentVariablesJson:
-    description: JSON object representing environment variables that can be passed to the 'scripted-build-pipeline' re-usable workflow via its '*PhaseEnv' inputs.
+  environmentVariablesJsonBase64:
+    description: Base64-encoded JSON object representing environment variables that can be passed to the 'scripted-build-pipeline' re-usable workflow via its '*PhaseEnv' inputs.
     value: ${{ steps.prepareEnvVars.outputs.RESOLVED_ENV_VARS }}
-  secretsBase64:
+  secretsJsonBase64:
     description: Base64-encoded JSON object representing secrets that can be passed to the 'scripted-build-pipeline' re-usable workflow via its '*PhaseSecrets' inputs.
     value: ${{ steps.prepareSecrets.outputs.RESOLVED_SECRETS }}
 
@@ -24,7 +24,9 @@ runs:
       Write-Host "REQUIRED_ENV_VARS: ${{ inputs.environmentVariablesJson }}"
       $json = ConvertFrom-Json '${{ inputs.environmentVariablesJson }}' -Depth 100 | ConvertTo-Json -Depth 100 -Compress
       Write-Host "json: $json"
-      ("RESOLVED_ENV_VARS={0}" -f $json) | Out-File -Append $env:GITHUB_OUTPUT
+      $jsonb64 = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($json))
+      Write-Host "jsonb64: $jsonb64"
+      ("RESOLVED_ENV_VARS={0}" -f $jsonb64) | Out-File -Append $env:GITHUB_OUTPUT
     shell: pwsh
 
   - id: prepareSecrets

--- a/actions/set-env-vars-and-secrets/action.yml
+++ b/actions/set-env-vars-and-secrets/action.yml
@@ -1,0 +1,31 @@
+name: 'Endjin.RecommendedPractices.Build.SetEnvVarsAndSecret'
+description: 'Injects environment variables and secrets passed as JSON-formatted strings'
+inputs:
+  environmentVariablesJson:
+    description: A JSON object representing environment variables that need to be set for the current job.
+    default: '{}'
+  secretsJsonBase64:
+    description: A Base64-encoded JSON object representing secrets that need to be set for the current job.
+    default: 'ewB9AA=='   # '{}'
+
+runs:
+  using: "composite"
+  steps:
+  - id: setEnvironmentVariables
+    name: Set Environment Variables
+    run: |
+      $envVars = ConvertFrom-Json -Depth 100 -AsHashtable "${{ environmentVariablesJson }}"
+      $envVars.Keys | % {
+        ('{0}={1}' -f $_, $envVars[$_]) | Out-File -Append -FilePath $env:GITHUB_ENV
+      }        
+    shell: pwsh
+  - id: setSecrets
+    name: Set Secrets
+    run: |
+      $secretsJson = [System.Text.Encoding]::Unicode.GetString([Convert]::FromBase64String("${{ inputs.secretsJsonBase64 }}"))
+      $secrets = ConvertFrom-Json -Depth 100 -AsHashtable $secretsJson
+      $secrets.Keys | % {
+        ('{0}={1}' -f $_, $envVars[$_]) | Out-File -Append -FilePath $env:GITHUB_ENV
+        Write-Host ("::add-mask::{0}" -f $envVars[$_])
+      }        
+    shell: pwsh

--- a/actions/set-env-vars-and-secrets/action.yml
+++ b/actions/set-env-vars-and-secrets/action.yml
@@ -16,8 +16,8 @@ runs:
     run: |
       $envVarsJson = [System.Text.Encoding]::Unicode.GetString([Convert]::FromBase64String("${{ inputs.environmentVariablesJsonBase64 }}"))
       $envVars = ConvertFrom-Json -Depth 100 -AsHashtable $envVarsJson
-      $envVars.Keys | % {
-        ('{0}={1}' -f $_, $envVars[$_]) | Out-File -Append -FilePath $env:GITHUB_ENV
+      foreach ($envVarName in $envVars.Keys) {
+        ('{0}={1}' -f $envVarName, $envVars[$envVarName]) | Out-File -Append -FilePath $env:GITHUB_ENV
       }        
     shell: pwsh
   - id: setSecrets
@@ -25,8 +25,8 @@ runs:
     run: |
       $secretsJson = [System.Text.Encoding]::Unicode.GetString([Convert]::FromBase64String("${{ inputs.secretsJsonBase64 }}"))
       $secrets = ConvertFrom-Json -Depth 100 -AsHashtable $secretsJson
-      $secrets.Keys | % {
-        ('{0}={1}' -f $_, $secrets[$_]) | Out-File -Append -FilePath $env:GITHUB_ENV
-        Write-Host ("::add-mask::{0}" -f $secrets[$_])
+      foreach ($secretName in $secrets.Keys) {
+        ('{0}={1}' -f $secretName, $secrets[$secretName]) | Out-File -Append -FilePath $env:GITHUB_ENV
+        Write-Host ("::add-mask::{0}" -f $secrets[$secretName])
       }        
     shell: pwsh

--- a/actions/set-env-vars-and-secrets/action.yml
+++ b/actions/set-env-vars-and-secrets/action.yml
@@ -26,7 +26,7 @@ runs:
       $secretsJson = [System.Text.Encoding]::Unicode.GetString([Convert]::FromBase64String("${{ inputs.secretsJsonBase64 }}"))
       $secrets = ConvertFrom-Json -Depth 100 -AsHashtable $secretsJson
       $secrets.Keys | % {
-        ('{0}={1}' -f $_, $envVars[$_]) | Out-File -Append -FilePath $env:GITHUB_ENV
-        Write-Host ("::add-mask::{0}" -f $envVars[$_])
+        ('{0}={1}' -f $_, $secrets[$_]) | Out-File -Append -FilePath $env:GITHUB_ENV
+        Write-Host ("::add-mask::{0}" -f $secrets[$_])
       }        
     shell: pwsh

--- a/actions/set-env-vars-and-secrets/action.yml
+++ b/actions/set-env-vars-and-secrets/action.yml
@@ -1,9 +1,9 @@
 name: 'Endjin.RecommendedPractices.Build.SetEnvVarsAndSecret'
 description: 'Injects environment variables and secrets passed as JSON-formatted strings'
 inputs:
-  environmentVariablesJson:
-    description: A JSON object representing environment variables that need to be set for the current job.
-    default: '{}'
+  environmentVariablesJsonBase64:
+    description: A Base64-encoded JSON object representing environment variables that need to be set for the current job.
+    default: 'ewB9AA=='   # '{}'
   secretsJsonBase64:
     description: A Base64-encoded JSON object representing secrets that need to be set for the current job.
     default: 'ewB9AA=='   # '{}'
@@ -14,7 +14,8 @@ runs:
   - id: setEnvironmentVariables
     name: Set Environment Variables
     run: |
-      $envVars = ConvertFrom-Json -Depth 100 -AsHashtable "${{ environmentVariablesJson }}"
+      $envVarsJson = [System.Text.Encoding]::Unicode.GetString([Convert]::FromBase64String("${{ inputs.environmentVariablesJsonBase64 }}"))
+      $envVars = ConvertFrom-Json -Depth 100 -AsHashtable $envVarsJson
       $envVars.Keys | % {
         ('{0}={1}' -f $_, $envVars[$_]) | Out-File -Append -FilePath $env:GITHUB_ENV
       }        


### PR DESCRIPTION
This feature provides a workaround for the following limitations:
1. Unable to set environment variables on a job that calls a re-usable workflow
2. Unable to reference secrets when specifying the inputs to a re-useable workflow

Using the native functionality to achieve both of the above scenarios, requires the re-useable workflow to have knowledge of any environment variables or secrets that a calling workflow may wish to reference.  This is undesirable for a highly generalised re-usable workflow.

Also includes two new composite actions that encapsulate preparing and applying the specified environment variables and secrets.
* `prepare-env-vars-and-secrets` - used in the top-level workflow before calling the `scripted-build-pipeline` re-usable workflow
* `set-env-vars-and-secrets` - used by the `scripted-build-pipeline` re-usable workflow to dynamically inject environment variables into the current job