### PR TITLE
Add ability to upload artifact as part of publish phase

### DIFF
--- a/.github/workflows/scripted-build-pipeline.yml
+++ b/.github/workflows/scripted-build-pipeline.yml
@@ -95,7 +95,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/publish-gh-artifacts
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
       with: 
         environmentVariablesJsonBase64: ${{ inputs.compilePhaseEnv}}
         secretsJsonBase64: ${{ inputs.compilePhaseSecrets}}
@@ -119,7 +119,7 @@ jobs:
       with:
         creds: ${{ secrets.compilePhaseAzureCredentials }}
         enable-AzPSSession: true
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@feature/publish-gh-artifacts
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@main
       id: run_compile
       with:
         displayName: Compile & Analyse
@@ -142,7 +142,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/publish-gh-artifacts
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
       with: 
         environmentVariablesJsonBase64: ${{ inputs.testPhaseEnv}}
         secretsJsonBase64: ${{ inputs.testPhaseSecrets}}
@@ -166,7 +166,7 @@ jobs:
       with:
         creds: ${{ secrets.testPhaseAzureCredentials }}
         enable-AzPSSession: true
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@feature/publish-gh-artifacts
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@main
       with:
         displayName: Run Tests
         netSdkVersion: ${{ inputs.netSdkVersion }}
@@ -235,7 +235,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/publish-gh-artifacts
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
       with: 
         environmentVariablesJsonBase64: ${{ inputs.packagePhaseEnv}}
         secretsJsonBase64: ${{ inputs.packagePhaseSecrets}}
@@ -259,7 +259,7 @@ jobs:
       with:
         creds: ${{ secrets.packagePhaseAzureCredentials }}
         enable-AzPSSession: true     
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@feature/publish-gh-artifacts
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@main
       with:
         displayName: Build Packages
         netSdkVersion: ${{ inputs.netSdkVersion }}
@@ -290,7 +290,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/publish-gh-artifacts
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
       with: 
         environmentVariablesJsonBase64: ${{ inputs.publishPhaseEnv}}
         secretsJsonBase64: ${{ inputs.publishPhaseSecrets}}
@@ -314,7 +314,7 @@ jobs:
       with:
         creds: ${{ secrets.publishPhaseAzureCredentials }}
         enable-AzPSSession: true    
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@feature/publish-gh-artifacts
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@main
       with:
         displayName: Publish Packages
         netSdkVersion: ${{ inputs.netSdkVersion }}
@@ -341,6 +341,6 @@ jobs:
     # We need to checkout the repo to get the branch information
     - name: Check out code
       uses: actions/checkout@v3
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/remove-pipeline-state@feature/publish-gh-artifacts
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/remove-pipeline-state@main
       with:
         cacheKeyPrefix: build-state

--- a/.github/workflows/scripted-build-pipeline.yml
+++ b/.github/workflows/scripted-build-pipeline.yml
@@ -95,7 +95,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/publish-gh-actions
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/publish-gh-artifacts
       with: 
         environmentVariablesJsonBase64: ${{ inputs.compilePhaseEnv}}
         secretsJsonBase64: ${{ inputs.compilePhaseSecrets}}
@@ -119,7 +119,7 @@ jobs:
       with:
         creds: ${{ secrets.compilePhaseAzureCredentials }}
         enable-AzPSSession: true
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@feature/publish-gh-actions
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@feature/publish-gh-artifacts
       id: run_compile
       with:
         displayName: Compile & Analyse
@@ -142,7 +142,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/publish-gh-actions
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/publish-gh-artifacts
       with: 
         environmentVariablesJsonBase64: ${{ inputs.testPhaseEnv}}
         secretsJsonBase64: ${{ inputs.testPhaseSecrets}}
@@ -166,7 +166,7 @@ jobs:
       with:
         creds: ${{ secrets.testPhaseAzureCredentials }}
         enable-AzPSSession: true
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@feature/publish-gh-actions
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@feature/publish-gh-artifacts
       with:
         displayName: Run Tests
         netSdkVersion: ${{ inputs.netSdkVersion }}
@@ -235,7 +235,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/publish-gh-actions
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/publish-gh-artifacts
       with: 
         environmentVariablesJsonBase64: ${{ inputs.packagePhaseEnv}}
         secretsJsonBase64: ${{ inputs.packagePhaseSecrets}}
@@ -259,7 +259,7 @@ jobs:
       with:
         creds: ${{ secrets.packagePhaseAzureCredentials }}
         enable-AzPSSession: true     
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@feature/publish-gh-actions
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@feature/publish-gh-artifacts
       with:
         displayName: Build Packages
         netSdkVersion: ${{ inputs.netSdkVersion }}
@@ -290,7 +290,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/publish-gh-actions
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/publish-gh-artifacts
       with: 
         environmentVariablesJsonBase64: ${{ inputs.publishPhaseEnv}}
         secretsJsonBase64: ${{ inputs.publishPhaseSecrets}}
@@ -314,7 +314,7 @@ jobs:
       with:
         creds: ${{ secrets.publishPhaseAzureCredentials }}
         enable-AzPSSession: true    
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@feature/publish-gh-actions
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@feature/publish-gh-artifacts
       with:
         displayName: Publish Packages
         netSdkVersion: ${{ inputs.netSdkVersion }}
@@ -341,6 +341,6 @@ jobs:
     # We need to checkout the repo to get the branch information
     - name: Check out code
       uses: actions/checkout@v3
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/remove-pipeline-state@feature/publish-gh-actions
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/remove-pipeline-state@feature/publish-gh-artifacts
       with:
         cacheKeyPrefix: build-state

--- a/.github/workflows/scripted-build-pipeline.yml
+++ b/.github/workflows/scripted-build-pipeline.yml
@@ -95,7 +95,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
+    - uses: ./actions/set-env-vars-and-secrets
       with: 
         environmentVariablesJsonBase64: ${{ inputs.compilePhaseEnv}}
         secretsJsonBase64: ${{ inputs.compilePhaseSecrets}}
@@ -119,7 +119,7 @@ jobs:
       with:
         creds: ${{ secrets.compilePhaseAzureCredentials }}
         enable-AzPSSession: true
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@main
+    - uses: ./actions/run-scripted-build
       id: run_compile
       with:
         displayName: Compile & Analyse
@@ -142,7 +142,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
+    - uses: ./actions/set-env-vars-and-secrets
       with: 
         environmentVariablesJsonBase64: ${{ inputs.testPhaseEnv}}
         secretsJsonBase64: ${{ inputs.testPhaseSecrets}}
@@ -166,7 +166,7 @@ jobs:
       with:
         creds: ${{ secrets.testPhaseAzureCredentials }}
         enable-AzPSSession: true
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@main
+    - uses: ./actions/run-scripted-build
       with:
         displayName: Run Tests
         netSdkVersion: ${{ inputs.netSdkVersion }}
@@ -235,7 +235,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
+    - uses: ./actions/set-env-vars-and-secrets
       with: 
         environmentVariablesJsonBase64: ${{ inputs.packagePhaseEnv}}
         secretsJsonBase64: ${{ inputs.packagePhaseSecrets}}
@@ -259,7 +259,7 @@ jobs:
       with:
         creds: ${{ secrets.packagePhaseAzureCredentials }}
         enable-AzPSSession: true     
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@main
+    - uses: ./actions/run-scripted-build
       with:
         displayName: Build Packages
         netSdkVersion: ${{ inputs.netSdkVersion }}
@@ -290,7 +290,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
+    - uses: ./actions/set-env-vars-and-secrets
       with: 
         environmentVariablesJsonBase64: ${{ inputs.publishPhaseEnv}}
         secretsJsonBase64: ${{ inputs.publishPhaseSecrets}}
@@ -314,7 +314,7 @@ jobs:
       with:
         creds: ${{ secrets.publishPhaseAzureCredentials }}
         enable-AzPSSession: true    
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@main
+    - uses: ./actions/run-scripted-build
       with:
         displayName: Publish Packages
         netSdkVersion: ${{ inputs.netSdkVersion }}
@@ -341,6 +341,6 @@ jobs:
     # We need to checkout the repo to get the branch information
     - name: Check out code
       uses: actions/checkout@v3
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/remove-pipeline-state@main
+    - uses: ./actions/remove-pipeline-state
       with:
         cacheKeyPrefix: build-state

--- a/.github/workflows/scripted-build-pipeline.yml
+++ b/.github/workflows/scripted-build-pipeline.yml
@@ -51,7 +51,15 @@ on:
       publishPhaseSecrets:
         description: A Base64-encoded JSON object representing the secrets required when running the 'publish' stage of this workflow.
         required: false
-        type: string        
+        type: string    
+      publishArtifactName:
+        description: If set, during the publish phase, uploads a GitHub artifact with the provided name (path must be specified in `artifactPath`)
+        required: false
+        type: string  
+      publishArtifactPath:
+        description: If set, during the publish phase, uploads a GitHub artifact with the provided path (name must be specified in `artifactName`). The path can be a file, directory or wildcard pattern; multiple paths can be specified using newline demiliter.
+        required: false
+        type: string    
       forcePublish:
         description: When true, the Publish stage will be run regardless of the current branch or tag.
         required: false
@@ -315,6 +323,8 @@ jobs:
         inputCachePaths: |
           _packages
           ${{ inputs.additionalCachePaths }}
+        artifactName: ${{ inputs.publishArtifactName }}
+        artifactPath: ${{ inputs.publishArtifactPath }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/scripted-build-pipeline.yml
+++ b/.github/workflows/scripted-build-pipeline.yml
@@ -95,7 +95,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - uses: ./actions/set-env-vars-and-secrets
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
       with: 
         environmentVariablesJsonBase64: ${{ inputs.compilePhaseEnv}}
         secretsJsonBase64: ${{ inputs.compilePhaseSecrets}}
@@ -119,7 +119,7 @@ jobs:
       with:
         creds: ${{ secrets.compilePhaseAzureCredentials }}
         enable-AzPSSession: true
-    - uses: ./actions/run-scripted-build
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@main
       id: run_compile
       with:
         displayName: Compile & Analyse
@@ -142,7 +142,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - uses: ./actions/set-env-vars-and-secrets
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
       with: 
         environmentVariablesJsonBase64: ${{ inputs.testPhaseEnv}}
         secretsJsonBase64: ${{ inputs.testPhaseSecrets}}
@@ -166,7 +166,7 @@ jobs:
       with:
         creds: ${{ secrets.testPhaseAzureCredentials }}
         enable-AzPSSession: true
-    - uses: ./actions/run-scripted-build
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@main
       with:
         displayName: Run Tests
         netSdkVersion: ${{ inputs.netSdkVersion }}
@@ -235,7 +235,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - uses: ./actions/set-env-vars-and-secrets
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
       with: 
         environmentVariablesJsonBase64: ${{ inputs.packagePhaseEnv}}
         secretsJsonBase64: ${{ inputs.packagePhaseSecrets}}
@@ -259,7 +259,7 @@ jobs:
       with:
         creds: ${{ secrets.packagePhaseAzureCredentials }}
         enable-AzPSSession: true     
-    - uses: ./actions/run-scripted-build
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@main
       with:
         displayName: Build Packages
         netSdkVersion: ${{ inputs.netSdkVersion }}
@@ -290,7 +290,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - uses: ./actions/set-env-vars-and-secrets
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
       with: 
         environmentVariablesJsonBase64: ${{ inputs.publishPhaseEnv}}
         secretsJsonBase64: ${{ inputs.publishPhaseSecrets}}
@@ -314,7 +314,7 @@ jobs:
       with:
         creds: ${{ secrets.publishPhaseAzureCredentials }}
         enable-AzPSSession: true    
-    - uses: ./actions/run-scripted-build
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@main
       with:
         displayName: Publish Packages
         netSdkVersion: ${{ inputs.netSdkVersion }}
@@ -341,6 +341,6 @@ jobs:
     # We need to checkout the repo to get the branch information
     - name: Check out code
       uses: actions/checkout@v3
-    - uses: ./actions/remove-pipeline-state
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/remove-pipeline-state@main
       with:
         cacheKeyPrefix: build-state

--- a/.github/workflows/scripted-build-pipeline.yml
+++ b/.github/workflows/scripted-build-pipeline.yml
@@ -95,7 +95,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/publish-gh-actions
       with: 
         environmentVariablesJsonBase64: ${{ inputs.compilePhaseEnv}}
         secretsJsonBase64: ${{ inputs.compilePhaseSecrets}}
@@ -119,7 +119,7 @@ jobs:
       with:
         creds: ${{ secrets.compilePhaseAzureCredentials }}
         enable-AzPSSession: true
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@main
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@feature/publish-gh-actions
       id: run_compile
       with:
         displayName: Compile & Analyse
@@ -142,7 +142,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/publish-gh-actions
       with: 
         environmentVariablesJsonBase64: ${{ inputs.testPhaseEnv}}
         secretsJsonBase64: ${{ inputs.testPhaseSecrets}}
@@ -166,7 +166,7 @@ jobs:
       with:
         creds: ${{ secrets.testPhaseAzureCredentials }}
         enable-AzPSSession: true
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@main
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@feature/publish-gh-actions
       with:
         displayName: Run Tests
         netSdkVersion: ${{ inputs.netSdkVersion }}
@@ -235,7 +235,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/publish-gh-actions
       with: 
         environmentVariablesJsonBase64: ${{ inputs.packagePhaseEnv}}
         secretsJsonBase64: ${{ inputs.packagePhaseSecrets}}
@@ -259,7 +259,7 @@ jobs:
       with:
         creds: ${{ secrets.packagePhaseAzureCredentials }}
         enable-AzPSSession: true     
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@main
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@feature/publish-gh-actions
       with:
         displayName: Build Packages
         netSdkVersion: ${{ inputs.netSdkVersion }}
@@ -290,7 +290,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/publish-gh-actions
       with: 
         environmentVariablesJsonBase64: ${{ inputs.publishPhaseEnv}}
         secretsJsonBase64: ${{ inputs.publishPhaseSecrets}}
@@ -314,7 +314,7 @@ jobs:
       with:
         creds: ${{ secrets.publishPhaseAzureCredentials }}
         enable-AzPSSession: true    
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@main
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@feature/publish-gh-actions
       with:
         displayName: Publish Packages
         netSdkVersion: ${{ inputs.netSdkVersion }}
@@ -341,6 +341,6 @@ jobs:
     # We need to checkout the repo to get the branch information
     - name: Check out code
       uses: actions/checkout@v3
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/remove-pipeline-state@main
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/remove-pipeline-state@feature/publish-gh-actions
       with:
         cacheKeyPrefix: build-state

--- a/actions/run-scripted-build/action.yml
+++ b/actions/run-scripted-build/action.yml
@@ -111,7 +111,7 @@ runs:
 
   - name: Upload Artifact
     uses: actions/upload-artifact@v3
-    if: ${{ inputs.artifactName != '' && inputs.artifactPath != '' }}
+    if: inputs.artifactName != '' && inputs.artifactPath != ''
     with:
       name: ${{ inputs.artifactName }}
       path: ${{ inputs.artifactPath }}

--- a/actions/run-scripted-build/action.yml
+++ b/actions/run-scripted-build/action.yml
@@ -31,6 +31,16 @@ inputs:
     description: The build configuration to use
     required: false
     default: 'Release'
+  artifactName:
+    description: If set, uploads a GitHub artifact with the provided name (path must be specified in `artifactPath`)
+    required: false
+    default: ''
+  artifactPath:
+    description: If set, uploads a GitHub artifact with the provided path (name must be specified in `artifactName`). The path can be a file, directory or wildcard pattern; multiple paths can be specified using newline demiliter.
+    required: false
+    default: ''
+  
+
 outputs:
   semver:
     description: "The full SemVer version number of the current build"
@@ -98,3 +108,10 @@ runs:
     with:
       path: ${{ inputs.outputCachePaths }}
       key: build-state-${{ github.sha }}
+
+  - name: Upload Artifact
+    uses: actions/upload-artifact@v3
+    if: ${{ inputs.artifactName != '' && inputs.artifactPath != '' }}
+    with:
+      name: ${{ inputs.artifactName }}
+      path: ${{ inputs.artifactPath }}

--- a/actions/run-scripted-build/action.yml
+++ b/actions/run-scripted-build/action.yml
@@ -111,7 +111,7 @@ runs:
 
   - name: Upload Artifact
     uses: actions/upload-artifact@v3
-    if: inputs.artifactName != '' && inputs.artifactPath != ''
+    if: ${{ inputs.artifactName != '' && inputs.artifactPath != '' }}
     with:
       name: ${{ inputs.artifactName }}
       path: ${{ inputs.artifactPath }}


### PR DESCRIPTION
- Extends the composite 'run-scripted-build' action to upload an artifact when artifact name and path are supplied
- Extends the shared 'scripted-build-pipeline' workflow to pass through artifact name and path for publish phase