### PR TITLE
Remove cache clean-up stage

### DIFF
--- a/.github/workflows/scripted-build-pipeline.yml
+++ b/.github/workflows/scripted-build-pipeline.yml
@@ -340,20 +340,3 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         NUGET_API_KEY: ${{ env.NUGET_API_KEY }}
-
-  cleanup:
-    needs:
-    - compile
-    - test
-    - package
-    - publish
-    name: Cleanup
-    if: always() && !inputs.skipCleanup
-    runs-on: ubuntu-latest
-    steps:
-    # We need to checkout the repo to get the branch information
-    - name: Check out code
-      uses: actions/checkout@v3
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/remove-pipeline-state@main
-      with:
-        cacheKeyPrefix: build-state


### PR DESCRIPTION
This cache clean-up step currently prevents build stages from being re-run when they are broken by transient issues.

This change will allow us to evaluate the cost of relying on GHA's auto-eviction to determine whether it is worthwhile to implement our own overnight clean-up policy.