### PR TITLE
Add support for specifying custom build script

### DIFF
--- a/.github/workflows/scripted-build-pipeline.yml
+++ b/.github/workflows/scripted-build-pipeline.yml
@@ -111,7 +111,7 @@ jobs:
       preReleaseTag: ${{ steps.run_compile.outputs.preReleaseTag }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
       with:
         fetch-depth: 0
     - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
@@ -134,7 +134,7 @@ jobs:
         fi
     - name: Azure CLI login
       if: ${{ steps.compilePhaseAzureCredentials_secret_check.outputs.available == 'true' }}
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d    # v1.6.1
       with:
         creds: ${{ secrets.compilePhaseAzureCredentials }}
         enable-AzPSSession: true
@@ -173,7 +173,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
       with:
         fetch-depth: 0
     - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
@@ -196,7 +196,7 @@ jobs:
         fi
     - name: Azure CLI login
       if: ${{ steps.testPhaseAzureCredentials_secret_check.outputs.available == 'true' }}
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d    # v1.6.1
       with:
         creds: ${{ secrets.testPhaseAzureCredentials }}
         enable-AzPSSession: true
@@ -240,13 +240,13 @@ jobs:
       shell: pwsh
     - name: Store Code Coverage Artefacts
       if: always() && steps.check_coverage.outputs.EXISTS == 'true'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8    # v4.3.0
       with:
         name: CoverageReport      
         path: _codeCoverage
     - name: Generate Code Coverage Summary Report
       if: always() && steps.check_coverage.outputs.EXISTS == 'true'
-      uses: irongut/CodeCoverageSummary@v1.3.0
+      uses: irongut/CodeCoverageSummary@51cc3a756ddcd398d447c044c02cb6aa83fdae95    # v1.3.0
       with:
         filename: ${{ env.CODE_COVERAGE_RESULTS_DIR }}/${{ env.CODE_COVERAGE_RESULTS_FILE }}
         badge: true
@@ -259,13 +259,13 @@ jobs:
         thresholds: '${{ env.CODE_COVERAGE_LOWER_THRESHOLD }} ${{ env.CODE_COVERAGE_UPPER_THRESHOLD }}'
     - name: Publish Code Coverage Summary Report
       if: always() && steps.check_coverage.outputs.EXISTS == 'true'
-      uses: dtinth/markdown-report-action@v1
+      uses: dtinth/markdown-report-action@af8143d37cced4c514fd67539a2e58c2f432da09    # v1.0.0
       with:
         name: Code Coverage
         title: Code Coverage Report
         body-file: code-coverage-results.md
     - name: Publish Test Results
-      uses: EnricoMi/publish-unit-test-result-action@v2
+      uses: EnricoMi/publish-unit-test-result-action@e780361cd1fc1b1a170624547b3ffda64787d365   # v2.12.0
       if: always()
       with:
         nunit_files: "*TestResults.xml"    # produced by Pester
@@ -278,7 +278,7 @@ jobs:
     name: Package
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
       with:
         fetch-depth: 0
     - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
@@ -301,7 +301,7 @@ jobs:
         fi
     - name: Azure CLI login
       if: ${{ steps.packagePhaseAzureCredentials_secret_check.outputs.available == 'true' }}
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d    # v1.6.1
       with:
         creds: ${{ secrets.packagePhaseAzureCredentials }}
         enable-AzPSSession: true     
@@ -334,7 +334,7 @@ jobs:
       contents: write
       packages: write
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11   #v4.1.1
       with:
         fetch-depth: 0
     - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
@@ -357,7 +357,7 @@ jobs:
         fi
     - name: Azure CLI login
       if: ${{ steps.publishPhaseAzureCredentials_secret_check.outputs.available == 'true' }}
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d    # v1.6.1
       with:
         creds: ${{ secrets.publishPhaseAzureCredentials }}
         enable-AzPSSession: true    

--- a/.github/workflows/scripted-build-pipeline.yml
+++ b/.github/workflows/scripted-build-pipeline.yml
@@ -66,6 +66,11 @@ on:
         required: false
         default: false
         type: boolean
+      buildScriptPath:
+          description: The path to the build script to run.
+          required: false
+          default: ./build.ps1
+          type: string
 
     secrets:
       compilePhaseAzureCredentials:
@@ -133,10 +138,11 @@ jobs:
       with:
         creds: ${{ secrets.compilePhaseAzureCredentials }}
         enable-AzPSSession: true
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@main
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@feature/add-custom-build-script-support
       id: run_compile
       with:
         displayName: Compile & Analyse
+        buildScriptPath: ${{ inputs.buildScriptPath }}
         netSdkVersion: ${{ inputs.netSdkVersion }}
         additionalNetSdkVersion: ${{ inputs.additionalNetSdkVersion }}
         pythonVersion: ${{ inputs.pythonVersion }}
@@ -194,9 +200,10 @@ jobs:
       with:
         creds: ${{ secrets.testPhaseAzureCredentials }}
         enable-AzPSSession: true
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@main
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@feature/add-custom-build-script-support
       with:
         displayName: Run Tests
+        buildScriptPath: ${{ inputs.buildScriptPath }}
         netSdkVersion: ${{ inputs.netSdkVersion }}
         additionalNetSdkVersion: ${{ inputs.additionalNetSdkVersion }}
         tasks: 'Test,TestReport'
@@ -298,9 +305,10 @@ jobs:
       with:
         creds: ${{ secrets.packagePhaseAzureCredentials }}
         enable-AzPSSession: true     
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@main
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@feature/add-custom-build-script-support
       with:
         displayName: Build Packages
+        buildScriptPath: ${{ inputs.buildScriptPath }}
         netSdkVersion: ${{ inputs.netSdkVersion }}
         additionalNetSdkVersion: ${{ inputs.additionalNetSdkVersion }}
         tasks: 'Package'
@@ -353,9 +361,10 @@ jobs:
       with:
         creds: ${{ secrets.publishPhaseAzureCredentials }}
         enable-AzPSSession: true    
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@main
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@feature/add-custom-build-script-support
       with:
         displayName: Publish Packages
+        buildScriptPath: ${{ inputs.buildScriptPath }}
         netSdkVersion: ${{ inputs.netSdkVersion }}
         additionalNetSdkVersion: ${{ inputs.additionalNetSdkVersion }}
         tasks: 'Publish'

--- a/.github/workflows/scripted-build-pipeline.yml
+++ b/.github/workflows/scripted-build-pipeline.yml
@@ -138,7 +138,7 @@ jobs:
       with:
         creds: ${{ secrets.compilePhaseAzureCredentials }}
         enable-AzPSSession: true
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@feature/add-custom-build-script-support
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@main
       id: run_compile
       with:
         displayName: Compile & Analyse
@@ -200,7 +200,7 @@ jobs:
       with:
         creds: ${{ secrets.testPhaseAzureCredentials }}
         enable-AzPSSession: true
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@feature/add-custom-build-script-support
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@main
       with:
         displayName: Run Tests
         buildScriptPath: ${{ inputs.buildScriptPath }}
@@ -305,7 +305,7 @@ jobs:
       with:
         creds: ${{ secrets.packagePhaseAzureCredentials }}
         enable-AzPSSession: true     
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@feature/add-custom-build-script-support
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@main
       with:
         displayName: Build Packages
         buildScriptPath: ${{ inputs.buildScriptPath }}
@@ -361,7 +361,7 @@ jobs:
       with:
         creds: ${{ secrets.publishPhaseAzureCredentials }}
         enable-AzPSSession: true    
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@feature/add-custom-build-script-support
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@main
       with:
         displayName: Publish Packages
         buildScriptPath: ${{ inputs.buildScriptPath }}

--- a/actions/run-scripted-build/action.yml
+++ b/actions/run-scripted-build/action.yml
@@ -42,6 +42,10 @@ inputs:
     description: If set, uploads a GitHub artifact with the provided path (name must be specified in `artifactName`). The path can be a file, directory or wildcard pattern; multiple paths can be specified using newline demiliter.
     required: false
     default: ''
+  buildScriptPath:
+    description: The path to the build script to run.
+    required: false
+    default: './build.ps1'
   
 
 outputs:
@@ -102,7 +106,7 @@ runs:
     name: ${{ inputs.displayName }}
     run: |
       $tasks = "${{ inputs.tasks }}" -split ","
-      ./build.ps1 -Tasks $tasks `
+      ${{ inputs.buildScriptPath }} -Tasks $tasks `
                   -Configuration ${{ inputs.configuration }}
     shell: pwsh
     env:

--- a/actions/run-scripted-build/action.yml
+++ b/actions/run-scripted-build/action.yml
@@ -65,20 +65,20 @@ outputs:
 runs:
   using: "composite"
   steps:
-  - uses: actions/setup-dotnet@v3
+  - uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3   # v4.0.0
     name: Install .NET Core SDK ${{ inputs.netSdkVersion }}
     with:
       dotnet-version: '${{ inputs.netSdkVersion }}'
       dotnet-quality: '${{ inputs.netSdkQuality }}'
   
-  - uses: actions/setup-dotnet@v3
+  - uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3   # v4.0.0
     if: ${{ inputs.additionalNetSdkVersion }}
     name: Install .NET Core SDK ${{ inputs.additionalNetSdkVersion }}
     with:
       dotnet-version: '${{ inputs.additionalNetSdkVersion }}'
       dotnet-quality: '${{ inputs.netSdkQuality }}'
 
-  - uses: actions/setup-python@v4
+  - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c   # v5.0.0
     if: ${{ inputs.pythonVersion }}
     with:
       python-version: '${{ inputs.pythonVersion }}'
@@ -92,7 +92,7 @@ runs:
   - name: Restore Cached Inputs
     if: inputs.inputCachePaths != ''
     id: cache_inputs_restore
-    uses: actions/cache/restore@v3
+    uses: actions/cache/restore@13aacd865c20de90d75de3b17ebe84f7a17d57d2    # v4.0.0
     with:
       path: ${{ inputs.inputCachePaths }}
       key: build-state-${{ github.sha }}
@@ -116,13 +116,13 @@ runs:
   - name: Save Cached Outputs
     id: cache_outputs_save
     if: inputs.outputCachePaths
-    uses: actions/cache/save@v3
+    uses: actions/cache/save@13aacd865c20de90d75de3b17ebe84f7a17d57d2    # v4.0.0
     with:
       path: ${{ inputs.outputCachePaths }}
       key: build-state-${{ github.sha }}
 
   - name: Upload Artifact
-    uses: actions/upload-artifact@v3
+    uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8    # v4.3.0
     if: ${{ always() && inputs.artifactName != '' && inputs.artifactPath != '' }}
     with:
       name: ${{ inputs.artifactName }}


### PR DESCRIPTION
* New workflow input `buildScriptPath` to allow overriding the default build script to run
* 3rd party actions now pinned to a SHA, rather than a floating tag (as a software supply-chain attack mitigation)
* Updated 3rd party actions to latest versions to suppress `nodejs` deprecation warnings

Changes tested [here](https://github.com/endjin/spark-sandbox/actions/runs/7725279650).

***NOTE**: We await a new version of `azure/login` built against a later version of `nodejs`. (ref: https://github.com/Azure/login/pull/411)* 