### PR TITLE
Skip publishing code coverage report when running from a fork

### DIFF
--- a/.github/workflows/scripted-build-pipeline.yml
+++ b/.github/workflows/scripted-build-pipeline.yml
@@ -258,7 +258,8 @@ jobs:
         output: both
         thresholds: '${{ env.CODE_COVERAGE_LOWER_THRESHOLD }} ${{ env.CODE_COVERAGE_UPPER_THRESHOLD }}'
     - name: Publish Code Coverage Summary Report
-      if: always() && steps.check_coverage.outputs.EXISTS == 'true'
+      # NOTE: Skip this is we're running from a fork, as we won't have permissions to annotate the check run
+      if: always() && steps.check_coverage.outputs.EXISTS == 'true' && github.event.pull_request.head.repo.full_name == github.repository
       uses: dtinth/markdown-report-action@af8143d37cced4c514fd67539a2e58c2f432da09    # v1.0.0
       with:
         name: Code Coverage

--- a/actions/vellum-site-deploy/action.yml
+++ b/actions/vellum-site-deploy/action.yml
@@ -112,5 +112,3 @@ runs:
       action: upload
       app_location: website
       skip_app_build: true
-      skip_api_build: true
-      production_branch: main


### PR DESCRIPTION
The run will have insufficient permissions to annotate the check run with the code coverage details.

Also removed some now redundant properties from the SWA deployment action.