### PR TITLE
Bump `azure/login` action version

### DIFF
--- a/.github/workflows/scripted-build-pipeline.yml
+++ b/.github/workflows/scripted-build-pipeline.yml
@@ -134,7 +134,7 @@ jobs:
         fi
     - name: Azure CLI login
       if: ${{ steps.compilePhaseAzureCredentials_secret_check.outputs.available == 'true' }}
-      uses: azure/login@8c334a195cbb38e46038007b304988d888bf676a    # v2.0.0
+      uses: azure/login@6c251865b4e6290e7b78be643ea2d005bc51f69a    # v2.1.1
       with:
         creds: ${{ secrets.compilePhaseAzureCredentials }}
         enable-AzPSSession: true
@@ -196,7 +196,7 @@ jobs:
         fi
     - name: Azure CLI login
       if: ${{ steps.testPhaseAzureCredentials_secret_check.outputs.available == 'true' }}
-      uses: azure/login@8c334a195cbb38e46038007b304988d888bf676a    # v2.0.0
+      uses: azure/login@6c251865b4e6290e7b78be643ea2d005bc51f69a    # v2.1.1
       with:
         creds: ${{ secrets.testPhaseAzureCredentials }}
         enable-AzPSSession: true
@@ -308,7 +308,7 @@ jobs:
         fi
     - name: Azure CLI login
       if: ${{ steps.packagePhaseAzureCredentials_secret_check.outputs.available == 'true' }}
-      uses: azure/login@8c334a195cbb38e46038007b304988d888bf676a    # v2.0.0
+      uses: azure/login@6c251865b4e6290e7b78be643ea2d005bc51f69a    # v2.1.1
       with:
         creds: ${{ secrets.packagePhaseAzureCredentials }}
         enable-AzPSSession: true     
@@ -364,7 +364,7 @@ jobs:
         fi
     - name: Azure CLI login
       if: ${{ steps.publishPhaseAzureCredentials_secret_check.outputs.available == 'true' }}
-      uses: azure/login@8c334a195cbb38e46038007b304988d888bf676a    # v2.0.0
+      uses: azure/login@6c251865b4e6290e7b78be643ea2d005bc51f69a    # v2.1.1
       with:
         creds: ${{ secrets.publishPhaseAzureCredentials }}
         enable-AzPSSession: true    

--- a/actions/vellum-site-deploy/action.yml
+++ b/actions/vellum-site-deploy/action.yml
@@ -49,7 +49,7 @@ runs:
     working-directory: ${{ github.workspace }}
     shell: bash
 
-  - uses: azure/login@8c334a195cbb38e46038007b304988d888bf676a    # v2.0.0
+  - uses: azure/login@6c251865b4e6290e7b78be643ea2d005bc51f69a    # v2.1.1
     with:
       client-id: ${{ inputs.azureClientId }}
       tenant-id: ${{ inputs.azureTenantId }}


### PR DESCRIPTION
This resolves an ongoing issue caused by the action auto-updating to a new major release of the `Az.Accounts` module.

Ref: https://github.com/Azure/login/issues/447