### PR TITLE
Fix bug with `run-build-process` composite action & `azure/login` speed-up 

### DIFF
--- a/.github/workflows/scripted-build-matrix-pipeline.yml
+++ b/.github/workflows/scripted-build-matrix-pipeline.yml
@@ -163,7 +163,7 @@ jobs:
         fi
     - name: Azure CLI login
       if: ${{ steps.compilePhaseAzureCredentials_secret_check.outputs.available == 'true' }}
-      uses: azure/login@6c251865b4e6290e7b78be643ea2d005bc51f69a    # v2.1.1
+      uses: endjin/login@4ae41681a03e0285d0a85d578968b6ba937c23ee     # forked version including hotfix from https://github.com/Azure/login/pull/431
       with:
         creds: ${{ secrets.compilePhaseAzureCredentials }}
         enable-AzPSSession: true
@@ -229,7 +229,7 @@ jobs:
         fi
     - name: Azure CLI login
       if: ${{ steps.testPhaseAzureCredentials_secret_check.outputs.available == 'true' }}
-      uses: azure/login@6c251865b4e6290e7b78be643ea2d005bc51f69a    # v2.1.1
+      uses: endjin/login@4ae41681a03e0285d0a85d578968b6ba937c23ee     # forked version including hotfix from https://github.com/Azure/login/pull/431
       with:
         creds: ${{ secrets.testPhaseAzureCredentials }}
         enable-AzPSSession: true
@@ -344,7 +344,7 @@ jobs:
         fi
     - name: Azure CLI login
       if: ${{ steps.packagePhaseAzureCredentials_secret_check.outputs.available == 'true' }}
-      uses: azure/login@6c251865b4e6290e7b78be643ea2d005bc51f69a    # v2.1.1
+      uses: endjin/login@4ae41681a03e0285d0a85d578968b6ba937c23ee     # forked version including hotfix from https://github.com/Azure/login/pull/431
       with:
         creds: ${{ secrets.packagePhaseAzureCredentials }}
         enable-AzPSSession: true     
@@ -401,7 +401,7 @@ jobs:
         fi
     - name: Azure CLI login
       if: ${{ steps.publishPhaseAzureCredentials_secret_check.outputs.available == 'true' }}
-      uses: azure/login@6c251865b4e6290e7b78be643ea2d005bc51f69a    # v2.1.1
+      uses: endjin/login@4ae41681a03e0285d0a85d578968b6ba937c23ee     # forked version including hotfix from https://github.com/Azure/login/pull/431
       with:
         creds: ${{ secrets.publishPhaseAzureCredentials }}
         enable-AzPSSession: true    

--- a/.github/workflows/scripted-build-pipeline.yml
+++ b/.github/workflows/scripted-build-pipeline.yml
@@ -138,7 +138,7 @@ jobs:
         fi
     - name: Azure CLI login
       if: ${{ steps.compilePhaseAzureCredentials_secret_check.outputs.available == 'true' }}
-      uses: azure/login@6c251865b4e6290e7b78be643ea2d005bc51f69a    # v2.1.1
+      uses: endjin/login@4ae41681a03e0285d0a85d578968b6ba937c23ee     # forked version including hotfix from https://github.com/Azure/login/pull/431
       with:
         creds: ${{ secrets.compilePhaseAzureCredentials }}
         enable-AzPSSession: true
@@ -200,7 +200,7 @@ jobs:
         fi
     - name: Azure CLI login
       if: ${{ steps.testPhaseAzureCredentials_secret_check.outputs.available == 'true' }}
-      uses: azure/login@6c251865b4e6290e7b78be643ea2d005bc51f69a    # v2.1.1
+      uses: endjin/login@4ae41681a03e0285d0a85d578968b6ba937c23ee     # forked version including hotfix from https://github.com/Azure/login/pull/431
       with:
         creds: ${{ secrets.testPhaseAzureCredentials }}
         enable-AzPSSession: true
@@ -313,7 +313,7 @@ jobs:
         fi
     - name: Azure CLI login
       if: ${{ steps.packagePhaseAzureCredentials_secret_check.outputs.available == 'true' }}
-      uses: azure/login@6c251865b4e6290e7b78be643ea2d005bc51f69a    # v2.1.1
+      uses: endjin/login@4ae41681a03e0285d0a85d578968b6ba937c23ee     # forked version including hotfix from https://github.com/Azure/login/pull/431
       with:
         creds: ${{ secrets.packagePhaseAzureCredentials }}
         enable-AzPSSession: true     
@@ -369,7 +369,7 @@ jobs:
         fi
     - name: Azure CLI login
       if: ${{ steps.publishPhaseAzureCredentials_secret_check.outputs.available == 'true' }}
-      uses: azure/login@6c251865b4e6290e7b78be643ea2d005bc51f69a    # v2.1.1
+      uses: endjin/login@4ae41681a03e0285d0a85d578968b6ba937c23ee     # forked version including hotfix from https://github.com/Azure/login/pull/431
       with:
         creds: ${{ secrets.publishPhaseAzureCredentials }}
         enable-AzPSSession: true    

--- a/actions/run-build-process/action.yml
+++ b/actions/run-build-process/action.yml
@@ -93,9 +93,9 @@ runs:
     - name: Set defaults
       id: set_defaults
       run: |
-        echo "CODE_COVERAGE_SUMMARY_FILE=${{ inputs.codeCoverageSummaryDir || '_codeCoverage' }}" >> $GITHUB_ENV
-        echo "CODE_COVERAGE_SUMMARY_FILE=${{ inputs.codeCoverageSummaryFile || 'SummaryGithub.md' }}" >> $GITHUB_ENV
-        echo "DEFAULT_BUILD_TASKS=${{ (inputs.forcePublish == 'true' || startsWith(github.ref, 'refs/tags/')) && 'FullBuildAndPublish' || 'FullBuild' }}" >> $GITHUB_ENV
+        echo "CODE_COVERAGE_SUMMARY_FILE=${{ inputs.codeCoverageSummaryDir || '_codeCoverage' }}" >> $GITHUB_OUTPUT
+        echo "CODE_COVERAGE_SUMMARY_FILE=${{ inputs.codeCoverageSummaryFile || 'SummaryGithub.md' }}" >> $GITHUB_OUTPUT
+        echo "DEFAULT_BUILD_TASKS=${{ (inputs.forcePublish == 'true' || startsWith(github.ref, 'refs/tags/')) && 'FullBuildAndPublish' || 'FullBuild' }}" >> $GITHUB_OUTPUT
       shell: bash
     - name: Debug Variables
       if: env.ACTIONS_RUNNER_DEBUG == 'true'
@@ -113,12 +113,13 @@ runs:
         fi
     - name: Azure CLI login
       if: ${{ steps.buildAzureCredentials_secret_check.outputs.available == 'true' }}
-      uses: azure/login@6c251865b4e6290e7b78be643ea2d005bc51f69a    # v2.1.1
+      uses: endjin/login@4ae41681a03e0285d0a85d578968b6ba937c23ee     # forked version including hotfix from https://github.com/Azure/login/pull/431
       with:
         creds: ${{ inputs.buildAzureCredentials }}
         enable-AzPSSession: true
     - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@main
       id: run_build
+      name: Run Build
       with:
         displayName: Run Build
         buildScriptPath: ${{ inputs.buildScriptPath }}

--- a/actions/run-build-process/action.yml
+++ b/actions/run-build-process/action.yml
@@ -93,6 +93,8 @@ runs:
     - name: Set defaults
       id: set_defaults
       run: |
+        echo "inputs: ${{ toJson(inputs) }}"
+        echo "ref: ${{ github.ref }}"
         echo "CODE_COVERAGE_SUMMARY_FILE=${{ inputs.codeCoverageSummaryDir || '_codeCoverage' }}" >> $GITHUB_OUTPUT
         echo "CODE_COVERAGE_SUMMARY_FILE=${{ inputs.codeCoverageSummaryFile || 'SummaryGithub.md' }}" >> $GITHUB_OUTPUT
         echo "DEFAULT_BUILD_TASKS=${{ (inputs.forcePublish == 'true' || startsWith(github.ref, 'refs/tags/')) && 'FullBuildAndPublish' || 'FullBuild' }}" >> $GITHUB_OUTPUT

--- a/actions/run-scripted-build/action.yml
+++ b/actions/run-scripted-build/action.yml
@@ -113,6 +113,7 @@ runs:
     name: ${{ inputs.displayName }}
     run: |
       $tasks = "${{ inputs.tasks }}" -split ","
+      Write-Host "Running Tasks: $tasks"
       ${{ inputs.buildScriptPath }} -Tasks $tasks `
                   -Configuration ${{ inputs.configuration }}
     shell: pwsh


### PR DESCRIPTION
- Fixes an issue where certain values were being stored as environment variables rather than step outputs, and therefore were not available as expected later in the process
- Switches over builds to use our [forked version](https://github.com/endjin/azure) of `azure/login` with a [fix for its slowness](https://github.com/Azure/login/pull/431), whilst we wait for the official release