### PR TITLE
Revert to official `azure/login` task now the fix is released

### DIFF
--- a/.github/workflows/scripted-build-matrix-pipeline.yml
+++ b/.github/workflows/scripted-build-matrix-pipeline.yml
@@ -163,7 +163,7 @@ jobs:
         fi
     - name: Azure CLI login
       if: ${{ steps.compilePhaseAzureCredentials_secret_check.outputs.available == 'true' }}
-      uses: endjin/login@4ae41681a03e0285d0a85d578968b6ba937c23ee     # forked version including hotfix from https://github.com/Azure/login/pull/431
+      uses: azure/login@a65d910e8af852a8061c627c456678983e180302    # v2.2.0
       with:
         creds: ${{ secrets.compilePhaseAzureCredentials }}
         enable-AzPSSession: true
@@ -229,7 +229,7 @@ jobs:
         fi
     - name: Azure CLI login
       if: ${{ steps.testPhaseAzureCredentials_secret_check.outputs.available == 'true' }}
-      uses: endjin/login@4ae41681a03e0285d0a85d578968b6ba937c23ee     # forked version including hotfix from https://github.com/Azure/login/pull/431
+      uses: azure/login@a65d910e8af852a8061c627c456678983e180302    # v2.2.0
       with:
         creds: ${{ secrets.testPhaseAzureCredentials }}
         enable-AzPSSession: true
@@ -344,7 +344,7 @@ jobs:
         fi
     - name: Azure CLI login
       if: ${{ steps.packagePhaseAzureCredentials_secret_check.outputs.available == 'true' }}
-      uses: endjin/login@4ae41681a03e0285d0a85d578968b6ba937c23ee     # forked version including hotfix from https://github.com/Azure/login/pull/431
+      uses: azure/login@a65d910e8af852a8061c627c456678983e180302    # v2.2.0
       with:
         creds: ${{ secrets.packagePhaseAzureCredentials }}
         enable-AzPSSession: true     
@@ -401,7 +401,7 @@ jobs:
         fi
     - name: Azure CLI login
       if: ${{ steps.publishPhaseAzureCredentials_secret_check.outputs.available == 'true' }}
-      uses: endjin/login@4ae41681a03e0285d0a85d578968b6ba937c23ee     # forked version including hotfix from https://github.com/Azure/login/pull/431
+      uses: azure/login@a65d910e8af852a8061c627c456678983e180302    # v2.2.0
       with:
         creds: ${{ secrets.publishPhaseAzureCredentials }}
         enable-AzPSSession: true    

--- a/.github/workflows/scripted-build-pipeline.yml
+++ b/.github/workflows/scripted-build-pipeline.yml
@@ -138,7 +138,7 @@ jobs:
         fi
     - name: Azure CLI login
       if: ${{ steps.compilePhaseAzureCredentials_secret_check.outputs.available == 'true' }}
-      uses: endjin/login@4ae41681a03e0285d0a85d578968b6ba937c23ee     # forked version including hotfix from https://github.com/Azure/login/pull/431
+      uses: azure/login@a65d910e8af852a8061c627c456678983e180302    # v2.2.0
       with:
         creds: ${{ secrets.compilePhaseAzureCredentials }}
         enable-AzPSSession: true
@@ -200,7 +200,7 @@ jobs:
         fi
     - name: Azure CLI login
       if: ${{ steps.testPhaseAzureCredentials_secret_check.outputs.available == 'true' }}
-      uses: endjin/login@4ae41681a03e0285d0a85d578968b6ba937c23ee     # forked version including hotfix from https://github.com/Azure/login/pull/431
+      uses: azure/login@a65d910e8af852a8061c627c456678983e180302    # v2.2.0
       with:
         creds: ${{ secrets.testPhaseAzureCredentials }}
         enable-AzPSSession: true
@@ -313,7 +313,7 @@ jobs:
         fi
     - name: Azure CLI login
       if: ${{ steps.packagePhaseAzureCredentials_secret_check.outputs.available == 'true' }}
-      uses: endjin/login@4ae41681a03e0285d0a85d578968b6ba937c23ee     # forked version including hotfix from https://github.com/Azure/login/pull/431
+      uses: azure/login@a65d910e8af852a8061c627c456678983e180302    # v2.2.0
       with:
         creds: ${{ secrets.packagePhaseAzureCredentials }}
         enable-AzPSSession: true     
@@ -369,7 +369,7 @@ jobs:
         fi
     - name: Azure CLI login
       if: ${{ steps.publishPhaseAzureCredentials_secret_check.outputs.available == 'true' }}
-      uses: endjin/login@4ae41681a03e0285d0a85d578968b6ba937c23ee     # forked version including hotfix from https://github.com/Azure/login/pull/431
+      uses: azure/login@a65d910e8af852a8061c627c456678983e180302    # v2.2.0
       with:
         creds: ${{ secrets.publishPhaseAzureCredentials }}
         enable-AzPSSession: true    

--- a/actions/run-build-process/action.yml
+++ b/actions/run-build-process/action.yml
@@ -115,7 +115,7 @@ runs:
         fi
     - name: Azure CLI login
       if: ${{ steps.buildAzureCredentials_secret_check.outputs.available == 'true' }}
-      uses: endjin/login@4ae41681a03e0285d0a85d578968b6ba937c23ee     # forked version including hotfix from https://github.com/Azure/login/pull/431
+      uses: azure/login@a65d910e8af852a8061c627c456678983e180302    # v2.2.0
       with:
         creds: ${{ inputs.buildAzureCredentials }}
         enable-AzPSSession: true

--- a/actions/vellum-site-deploy/action.yml
+++ b/actions/vellum-site-deploy/action.yml
@@ -49,7 +49,7 @@ runs:
     working-directory: ${{ github.workspace }}
     shell: bash
 
-  - uses: endjin/login@4ae41681a03e0285d0a85d578968b6ba937c23ee     # forked version including hotfix from https://github.com/Azure/login/pull/431
+  - uses: azure/login@a65d910e8af852a8061c627c456678983e180302    # v2.2.0
     with:
       client-id: ${{ inputs.azureClientId }}
       tenant-id: ${{ inputs.azureTenantId }}


### PR DESCRIPTION
This is the [release](https://github.com/Azure/login/releases/tag/v2.2.0) we have been waiting for, whilst using our forked version in the meantime.