### PR TITLE
Update Vellum-related composite actions

### DIFF
--- a/actions/run-scripted-build/action.yml
+++ b/actions/run-scripted-build/action.yml
@@ -118,7 +118,7 @@ runs:
                   -Configuration ${{ inputs.configuration }}
     shell: pwsh
     env:
-      GH_TOKEN: ${{ env.GH_TOKEN != '' ? env.GH_TOKEN | github.token }}
+      GH_TOKEN: ${{ env.GH_TOKEN != '' && env.GH_TOKEN || github.token }}
       NUGET_PACKAGES: ${{ github.workspace }}/.nuget-packages
 
   - name: Save Cached Outputs

--- a/actions/run-scripted-build/action.yml
+++ b/actions/run-scripted-build/action.yml
@@ -118,7 +118,7 @@ runs:
                   -Configuration ${{ inputs.configuration }}
     shell: pwsh
     env:
-      GH_TOKEN: ${{ github.token }}
+      GH_TOKEN: ${{ env.GH_TOKEN != '' ? env.GH_TOKEN | github.token }}
       NUGET_PACKAGES: ${{ github.workspace }}/.nuget-packages
 
   - name: Save Cached Outputs

--- a/actions/vellum-site-build-deploy/action.yml
+++ b/actions/vellum-site-build-deploy/action.yml
@@ -41,7 +41,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/vellum-site-build@feature/update-vellum-composite-action
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/vellum-site-build@main
       id: build
       with:
         githubVellumPat: ${{ inputs.github_reader_pat }}

--- a/actions/vellum-site-build-deploy/action.yml
+++ b/actions/vellum-site-build-deploy/action.yml
@@ -41,7 +41,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/vellum-site-build@main
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/vellum-site-build@feature/update-vellum-composite-action
       id: build
       with:
         githubVellumPat: ${{ inputs.github_reader_pat }}

--- a/actions/vellum-site-build/action.yml
+++ b/actions/vellum-site-build/action.yml
@@ -24,7 +24,7 @@ runs:
       restore-keys: |
         ${{ runner.os }}-npm-
 
-  - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@feature/update-vellum-composite-action
+  - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@main
     id: build
     with:
       additionalNetSdkVersion: '9.x'

--- a/actions/vellum-site-build/action.yml
+++ b/actions/vellum-site-build/action.yml
@@ -24,7 +24,7 @@ runs:
       restore-keys: |
         ${{ runner.os }}-npm-
 
-  - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@main
+  - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@feature/update-vellum-composite-action
     id: build
     with:
       additionalNetSdkVersion: '9.x'

--- a/actions/vellum-site-build/action.yml
+++ b/actions/vellum-site-build/action.yml
@@ -24,17 +24,15 @@ runs:
       restore-keys: |
         ${{ runner.os }}-npm-
 
-  - name: Build
+  - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@main
     id: build
-    run: |
-      if ($env:GITHUB_REF -eq "refs/heads/main") {
-        $env:BUILDVAR_RebuildSearchIndex = "True"
-      }
-      & ${{ inputs.buildScriptPath }} -Verbose
-    shell: pwsh
+    with:
+      additionalNetSdkVersion: '9.x'
+      tasks: '.'
     env:
       GH_TOKEN : ${{ inputs.githubVellumPat }}
       NPM_CACHE_HIT: ${{ steps.cache_npm_dependencies.outputs.cache-hit }}
+      BUILDVAR_RebuildSearchIndex: ${{ github.ref == 'refs/heads/main' && 'True' || 'False' }}
 
   - run: |
       zip -r website.zip ${{ github.workspace }}/.dist


### PR DESCRIPTION
* For consistency, switch them over to use the `run-scripted-build` composite action (rather then their own script invocation)
* Update `run-script-build` to support using a custom GitHub access token, when specified via the `GH_TOKEN` environment variable