### PR TITLE
Enusre .NET 8 is available for the `vellum-site-build` composite action

### DIFF
--- a/actions/vellum-site-build/action.yml
+++ b/actions/vellum-site-build/action.yml
@@ -27,6 +27,7 @@ runs:
   - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@main
     id: build
     with:
+      netSdkVersion: '8.x'
       additionalNetSdkVersion: '9.x'
       tasks: '.'
     env:


### PR DESCRIPTION
Workaround for .NET 8 vanishing from GHA hosted agents