### PR TITLE
Fixes some loose secrets handling

### DIFF
--- a/actions/prepare-env-vars-and-secrets/action.yml
+++ b/actions/prepare-env-vars-and-secrets/action.yml
@@ -33,7 +33,6 @@ runs:
       $yaml = ConvertFrom-Yaml $srcEnvVars | ConvertTo-Yaml
       Write-Host "yaml: $yaml"
       $yamlb64 = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($yaml))
-      Write-Host "yamlb64: $yamlb64"
       ("RESOLVED_ENV_VARS={0}" -f $yamlb64) | Out-File -Append $env:GITHUB_OUTPUT
     shell: pwsh
 
@@ -48,6 +47,6 @@ runs:
       $yaml = ConvertFrom-Yaml $srcSecrets | ConvertTo-Yaml
       Write-Host "yaml: $yaml"
       $yamlb64 = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($yaml))
-      Write-Host "yamlb64: $yamlb64"
+      Write-Host ("::add-mask::{0}" -f $yamlb64)
       ("RESOLVED_SECRETS={0}" -f $yamlb64) | Out-File -Append $env:GITHUB_OUTPUT
     shell: pwsh

--- a/actions/set-env-vars-and-secrets/action.yml
+++ b/actions/set-env-vars-and-secrets/action.yml
@@ -19,20 +19,25 @@ runs:
   - id: setEnvironmentVariables
     name: Set Environment Variables
     run: |
-      $envVarsYaml = [System.Text.Encoding]::Unicode.GetString([Convert]::FromBase64String("${{ inputs.environmentVariablesYamlBase64 }}"))
+      $envVarsYaml = [System.Text.Encoding]::Unicode.GetString([Convert]::FromBase64String($env:INCOMING_ENV_VARS))
       $envVars = ConvertFrom-Yaml $envVarsYaml
       foreach ($envVarName in $envVars.Keys) {
         ('{0}={1}' -f $envVarName, $envVars[$envVarName]) | Out-File -Append -FilePath $env:GITHUB_ENV
       }
     shell: pwsh
+    env:
+      INCOMING_ENV_VARS: ${{ inputs.environmentVariablesYamlBase64 }}
   - id: setSecrets
     name: Set Secrets
     run: |
       Import-Module Powershell-yaml
-      $secretsYaml = [System.Text.Encoding]::Unicode.GetString([Convert]::FromBase64String("${{ inputs.secretsYamlBase64 }}"))
+      Write-Host ("::add-mask::{0}" -f $env:INCOMING_SECRETS)
+      $secretsYaml = [System.Text.Encoding]::Unicode.GetString([Convert]::FromBase64String($env:INCOMING_SECRETS))
       $secrets = ConvertFrom-Yaml $secretsYaml
       foreach ($secretName in $secrets.Keys) {
         ('{0}={1}' -f $secretName, $secrets[$secretName]) | Out-File -Append -FilePath $env:GITHUB_ENV
         Write-Host ("::add-mask::{0}" -f $secrets[$secretName])
       }
     shell: pwsh
+    env:
+      INCOMING_SECRETS: ${{ inputs.secretsYamlBase64 }}


### PR DESCRIPTION
Updates the following composite actions:
- `prepare-env-vars-and-secrets`
- `set-env-vars-and-secrets`

Summary of changes:
- Removes logging of base64 strings
- Adds explicit GHA masking for the base64 strings
- Consume any base64 strings containing secrets via environment variables, to avoid another logging disclosure scenario (where GHA logs the contents of the script being run)