### PR TITLE
Fix issue with masked values not visible to other jobs

### DIFF
--- a/.github/workflows/scripted-build-matrix-pipeline.yml
+++ b/.github/workflows/scripted-build-matrix-pipeline.yml
@@ -146,7 +146,7 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/secrets-passing
       with: 
         environmentVariablesYamlBase64: ${{ inputs.compilePhaseEnv}}
         secretsYamlBase64: ${{ secrets.compilePhaseSecrets}}
@@ -213,7 +213,7 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
       with:
         fetch-depth: 0
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/secrets-passing
       with: 
         environmentVariablesYamlBase64: ${{ inputs.testPhaseEnv}}
         secretsYamlBase64: ${{ secrets.testPhaseSecrets}}
@@ -329,7 +329,7 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
       with:
         fetch-depth: 0
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/secrets-passing
       with: 
         environmentVariablesYamlBase64: ${{ inputs.packagePhaseEnv}}
         secretsYamlBase64: ${{ secrets.packagePhaseSecrets}}
@@ -387,7 +387,7 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11   #v4.1.1
       with:
         fetch-depth: 0
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/secrets-passing
       with: 
         environmentVariablesYamlBase64: ${{ inputs.publishPhaseEnv}}
         secretsYamlBase64: ${{ secrets.publishPhaseSecrets}}

--- a/.github/workflows/scripted-build-matrix-pipeline.yml
+++ b/.github/workflows/scripted-build-matrix-pipeline.yml
@@ -146,7 +146,7 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/secrets-passing
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
       with: 
         environmentVariablesYamlBase64: ${{ inputs.compilePhaseEnv}}
         secretsYamlBase64: ${{ secrets.compilePhaseSecrets}}
@@ -213,7 +213,7 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
       with:
         fetch-depth: 0
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/secrets-passing
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
       with: 
         environmentVariablesYamlBase64: ${{ inputs.testPhaseEnv}}
         secretsYamlBase64: ${{ secrets.testPhaseSecrets}}
@@ -329,7 +329,7 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
       with:
         fetch-depth: 0
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/secrets-passing
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
       with: 
         environmentVariablesYamlBase64: ${{ inputs.packagePhaseEnv}}
         secretsYamlBase64: ${{ secrets.packagePhaseSecrets}}
@@ -387,7 +387,7 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11   #v4.1.1
       with:
         fetch-depth: 0
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/secrets-passing
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
       with: 
         environmentVariablesYamlBase64: ${{ inputs.publishPhaseEnv}}
         secretsYamlBase64: ${{ secrets.publishPhaseSecrets}}

--- a/.github/workflows/scripted-build-matrix-pipeline.yml
+++ b/.github/workflows/scripted-build-matrix-pipeline.yml
@@ -123,6 +123,9 @@ on:
       publishPhaseSecrets:
         description: A YAML string representing a dictionary of secrets required when running the 'publish' stage of this workflow.
         required: false
+      secretsEncryptionKey:
+        description: A string representing the shared secret used to encrypt the secrets YAML object.
+        required: true
 
 env:
   CODE_COVERAGE_SUMMARY_DIR: ${{ vars.CODE_COVERAGE_SUMMARY_DIR || '_codeCoverage' }}
@@ -143,10 +146,11 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/secrets-passing
       with: 
         environmentVariablesYamlBase64: ${{ inputs.compilePhaseEnv}}
         secretsYamlBase64: ${{ secrets.compilePhaseSecrets}}
+        secretsEncryptionKey: ${{ secrets.secretsEncryptionKey }}
     - name: Debug Variables
       if: env.ACTIONS_RUNNER_DEBUG == 'true'
       run: |
@@ -209,10 +213,11 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
       with:
         fetch-depth: 0
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/secrets-passing
       with: 
         environmentVariablesYamlBase64: ${{ inputs.testPhaseEnv}}
         secretsYamlBase64: ${{ secrets.testPhaseSecrets}}
+        secretsEncryptionKey: ${{ secrets.secretsEncryptionKey }}
     - name: Debug Variables
       if: env.ACTIONS_RUNNER_DEBUG == 'true'
       run: |
@@ -324,10 +329,11 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
       with:
         fetch-depth: 0
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/secrets-passing
       with: 
         environmentVariablesYamlBase64: ${{ inputs.packagePhaseEnv}}
         secretsYamlBase64: ${{ secrets.packagePhaseSecrets}}
+        secretsEncryptionKey: ${{ secrets.secretsEncryptionKey }}
     - name: Debug Variables
       if: env.ACTIONS_RUNNER_DEBUG == 'true'
       run: |
@@ -381,10 +387,11 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11   #v4.1.1
       with:
         fetch-depth: 0
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/secrets-passing
       with: 
         environmentVariablesYamlBase64: ${{ inputs.publishPhaseEnv}}
         secretsYamlBase64: ${{ secrets.publishPhaseSecrets}}
+        secretsEncryptionKey: ${{ secrets.secretsEncryptionKey }}
     - name: Debug Variables
       if: env.ACTIONS_RUNNER_DEBUG == 'true'
       run: |

--- a/.github/workflows/scripted-build-matrix-pipeline.yml
+++ b/.github/workflows/scripted-build-matrix-pipeline.yml
@@ -125,7 +125,7 @@ on:
         required: false
       secretsEncryptionKey:
         description: A string representing the shared secret used to encrypt the secrets YAML object.
-        required: true
+        required: false
 
 env:
   CODE_COVERAGE_SUMMARY_DIR: ${{ vars.CODE_COVERAGE_SUMMARY_DIR || '_codeCoverage' }}

--- a/.github/workflows/scripted-build-pipeline.yml
+++ b/.github/workflows/scripted-build-pipeline.yml
@@ -121,7 +121,7 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/secrets-passing
       with: 
         environmentVariablesYamlBase64: ${{ inputs.compilePhaseEnv}}
         secretsYamlBase64: ${{ secrets.compilePhaseSecrets}}
@@ -184,7 +184,7 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         fetch-depth: 0
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/secrets-passing
       with: 
         environmentVariablesYamlBase64: ${{ inputs.testPhaseEnv}}
         secretsYamlBase64: ${{ secrets.testPhaseSecrets}}
@@ -298,7 +298,7 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
       with:
         fetch-depth: 0
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/secrets-passing
       with: 
         environmentVariablesYamlBase64: ${{ inputs.packagePhaseEnv}}
         secretsYamlBase64: ${{ secrets.packagePhaseSecrets}}
@@ -355,7 +355,7 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11   #v4.1.1
       with:
         fetch-depth: 0
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/secrets-passing
       with: 
         environmentVariablesYamlBase64: ${{ inputs.publishPhaseEnv}}
         secretsYamlBase64: ${{ secrets.publishPhaseSecrets}}

--- a/.github/workflows/scripted-build-pipeline.yml
+++ b/.github/workflows/scripted-build-pipeline.yml
@@ -121,7 +121,7 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/secrets-passing
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
       with: 
         environmentVariablesYamlBase64: ${{ inputs.compilePhaseEnv}}
         secretsYamlBase64: ${{ secrets.compilePhaseSecrets}}
@@ -184,7 +184,7 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         fetch-depth: 0
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/secrets-passing
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
       with: 
         environmentVariablesYamlBase64: ${{ inputs.testPhaseEnv}}
         secretsYamlBase64: ${{ secrets.testPhaseSecrets}}
@@ -298,7 +298,7 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
       with:
         fetch-depth: 0
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/secrets-passing
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
       with: 
         environmentVariablesYamlBase64: ${{ inputs.packagePhaseEnv}}
         secretsYamlBase64: ${{ secrets.packagePhaseSecrets}}
@@ -355,7 +355,7 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11   #v4.1.1
       with:
         fetch-depth: 0
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/secrets-passing
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
       with: 
         environmentVariablesYamlBase64: ${{ inputs.publishPhaseEnv}}
         secretsYamlBase64: ${{ secrets.publishPhaseSecrets}}

--- a/.github/workflows/scripted-build-pipeline.yml
+++ b/.github/workflows/scripted-build-pipeline.yml
@@ -100,7 +100,7 @@ on:
         required: false
       secretsEncryptionKey:
         description: A string representing the shared secret used to encrypt the secrets YAML object.
-        required: true
+        required: false
 
 env:
   CODE_COVERAGE_SUMMARY_DIR: ${{ vars.CODE_COVERAGE_SUMMARY_DIR || '_codeCoverage' }}

--- a/.github/workflows/scripted-build-pipeline.yml
+++ b/.github/workflows/scripted-build-pipeline.yml
@@ -98,6 +98,9 @@ on:
       publishPhaseSecrets:
         description: A YAML string representing a dictionary of secrets required when running the 'publish' stage of this workflow.
         required: false
+      secretsEncryptionKey:
+        description: A string representing the shared secret used to encrypt the secrets YAML object.
+        required: true
 
 env:
   CODE_COVERAGE_SUMMARY_DIR: ${{ vars.CODE_COVERAGE_SUMMARY_DIR || '_codeCoverage' }}
@@ -118,10 +121,11 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/secrets-passing
       with: 
         environmentVariablesYamlBase64: ${{ inputs.compilePhaseEnv}}
         secretsYamlBase64: ${{ secrets.compilePhaseSecrets}}
+        secretsEncryptionKey: ${{ secrets.secretsEncryptionKey }}
     - name: Debug Variables
       if: env.ACTIONS_RUNNER_DEBUG == 'true'
       run: |
@@ -180,10 +184,11 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         fetch-depth: 0
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/secrets-passing
       with: 
         environmentVariablesYamlBase64: ${{ inputs.testPhaseEnv}}
         secretsYamlBase64: ${{ secrets.testPhaseSecrets}}
+        secretsEncryptionKey: ${{ secrets.secretsEncryptionKey }}
     - name: Debug Variables
       if: env.ACTIONS_RUNNER_DEBUG == 'true'
       run: |
@@ -293,10 +298,11 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
       with:
         fetch-depth: 0
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/secrets-passing
       with: 
         environmentVariablesYamlBase64: ${{ inputs.packagePhaseEnv}}
         secretsYamlBase64: ${{ secrets.packagePhaseSecrets}}
+        secretsEncryptionKey: ${{ secrets.secretsEncryptionKey }}
     - name: Debug Variables
       if: env.ACTIONS_RUNNER_DEBUG == 'true'
       run: |
@@ -349,10 +355,11 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11   #v4.1.1
       with:
         fetch-depth: 0
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/secrets-passing
       with: 
         environmentVariablesYamlBase64: ${{ inputs.publishPhaseEnv}}
         secretsYamlBase64: ${{ secrets.publishPhaseSecrets}}
+        secretsEncryptionKey: ${{ secrets.secretsEncryptionKey }}
     - name: Debug Variables
       if: env.ACTIONS_RUNNER_DEBUG == 'true'
       run: |

--- a/.github/workflows/scripted-build-single-job-pipeline.yml
+++ b/.github/workflows/scripted-build-single-job-pipeline.yml
@@ -73,7 +73,7 @@ jobs:
       preReleaseTag: ${{ steps.run_build.outputs.preReleaseTag }}
 
     steps:
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-build-process@feature/secrets-passing
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-build-process@main
       id: run_build
       with:
         netSdkVersion: ${{ inputs.netSdkVersion }}

--- a/.github/workflows/scripted-build-single-job-pipeline.yml
+++ b/.github/workflows/scripted-build-single-job-pipeline.yml
@@ -73,7 +73,7 @@ jobs:
       preReleaseTag: ${{ steps.run_build.outputs.preReleaseTag }}
 
     steps:
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-build-process@main
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-build-process@feature/secrets-passing
       id: run_build
       with:
         netSdkVersion: ${{ inputs.netSdkVersion }}

--- a/.github/workflows/scripted-build-single-job-pipeline.yml
+++ b/.github/workflows/scripted-build-single-job-pipeline.yml
@@ -58,6 +58,9 @@ on:
       buildSecrets:
         description: A YAML string representing a dictionary of secrets required when running the 'compile' stage of this workflow.
         required: false
+      secretsEncryptionKey:
+        description: A string representing the shared secret used to encrypt the secrets YAML object.
+        required: false
 
 jobs:
   build:
@@ -92,3 +95,4 @@ jobs:
         buildSecrets: ${{ secrets.buildSecrets }}
         buildAzureCredentials: ${{ secrets.buildAzureCredentials }}
         token: ${{ secrets.GITHUB_TOKEN }}
+        secretsEncryptionKey: ${{ secrets.secretsEncryptionKey }}

--- a/actions/prepare-env-vars-and-secrets/action.yml
+++ b/actions/prepare-env-vars-and-secrets/action.yml
@@ -7,6 +7,9 @@ inputs:
   secretsYaml:
     description: A YAML object representing secrets that need to be passed into the 'scripted-build-pipeline' re-usable workflow via its '*PhaseSecrets' inputs.
     default: '{}'
+  # secretsEncryptionKey:
+  #   description: A string representing the shared secret used to encrypt the secrets YAML object.
+  #   required: true
 outputs:
   environmentVariablesYamlBase64:
     description: Base64-encoded YAML object representing environment variables that can be passed to the 'scripted-build-pipeline' re-usable workflow via its '*PhaseEnv' inputs.
@@ -46,7 +49,9 @@ runs:
       Write-Host "REQUIRED_SECRETS: $srcSecrets"
       $yaml = ConvertFrom-Yaml $srcSecrets | ConvertTo-Yaml
       Write-Host "yaml: $yaml"
-      $yamlb64 = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($yaml))
-      Write-Host ("::add-mask::{0}" -f $yamlb64)
-      ("RESOLVED_SECRETS={0}" -f $yamlb64) | Out-File -Append $env:GITHUB_OUTPUT
+      $keyBytes = [Convert]::FromBase64String($env:SECRETS_ENCRYPTION_KEY)
+      $secureYaml = ConvertFrom-SecureString (ConvertTo-SecureString $yaml -AsPlainText) -Key $keyBytes
+      ("RESOLVED_SECRETS={0}" -f $secureYaml) | Out-File -Append $env:GITHUB_OUTPUT
     shell: pwsh
+    env:
+      SECRETS_ENCRYPTION_KEY: ${{ secrets.WORKFLOW_SHARED_KEY }}

--- a/actions/prepare-env-vars-and-secrets/action.yml
+++ b/actions/prepare-env-vars-and-secrets/action.yml
@@ -44,6 +44,7 @@ runs:
     name: Prepare Secrets
     run: |
       if ([string]::IsNullOrEmpty($env:SECRETS_ENCRYPTION_KEY)) {
+          Write-Host "::warning title=Secrets skipped::Secrets cannot processed due to the encryption key not being provided. The calling workflow should ensure that the 'secretsEncryptionKey' input is set. The value is typically stored in the SHARED_WORKFLOW_KEY secret."
           Write-Warning "Secrets cannot processed due to the encryption key not being provided. The calling workflow should ensure that the 'secretsEncryptionKey' input is set. The value is typically stored in the SHARED_WORKFLOW_KEY secret."
       }
       else {

--- a/actions/prepare-env-vars-and-secrets/action.yml
+++ b/actions/prepare-env-vars-and-secrets/action.yml
@@ -7,9 +7,9 @@ inputs:
   secretsYaml:
     description: A YAML object representing secrets that need to be passed into the 'scripted-build-pipeline' re-usable workflow via its '*PhaseSecrets' inputs.
     default: '{}'
-  # secretsEncryptionKey:
-  #   description: A string representing the shared secret used to encrypt the secrets YAML object.
-  #   required: true
+  secretsEncryptionKey:
+    description: A string representing the shared secret used to encrypt the secrets YAML object.
+    required: true
 outputs:
   environmentVariablesYamlBase64:
     description: Base64-encoded YAML object representing environment variables that can be passed to the 'scripted-build-pipeline' re-usable workflow via its '*PhaseEnv' inputs.
@@ -54,4 +54,4 @@ runs:
       ("RESOLVED_SECRETS={0}" -f $secureYaml) | Out-File -Append $env:GITHUB_OUTPUT
     shell: pwsh
     env:
-      SECRETS_ENCRYPTION_KEY: ${{ secrets.WORKFLOW_SHARED_KEY }}
+      SECRETS_ENCRYPTION_KEY: ${{ inputs.secretsEncryptionKey }}

--- a/actions/prepare-env-vars-and-secrets/action.yml
+++ b/actions/prepare-env-vars-and-secrets/action.yml
@@ -48,8 +48,8 @@ runs:
       }
       else {
         $srcSecrets = @'
-        ${{ inputs.secretsYaml }}
-        '@
+      ${{ inputs.secretsYaml }}
+      '@
         Write-Host "REQUIRED_SECRETS: $srcSecrets"
         $yaml = ConvertFrom-Yaml $srcSecrets | ConvertTo-Yaml
         Write-Host "yaml: $yaml"

--- a/actions/prepare-env-vars-and-secrets/action.yml
+++ b/actions/prepare-env-vars-and-secrets/action.yml
@@ -9,7 +9,7 @@ inputs:
     default: '{}'
   secretsEncryptionKey:
     description: A string representing the shared secret used to encrypt the secrets YAML object.
-    required: true
+    required: false
 outputs:
   environmentVariablesYamlBase64:
     description: Base64-encoded YAML object representing environment variables that can be passed to the 'scripted-build-pipeline' re-usable workflow via its '*PhaseEnv' inputs.
@@ -43,15 +43,20 @@ runs:
   - id: prepareSecrets
     name: Prepare Secrets
     run: |
-      $srcSecrets = @'
-      ${{ inputs.secretsYaml }}
-      '@
-      Write-Host "REQUIRED_SECRETS: $srcSecrets"
-      $yaml = ConvertFrom-Yaml $srcSecrets | ConvertTo-Yaml
-      Write-Host "yaml: $yaml"
-      $keyBytes = [Convert]::FromBase64String($env:SECRETS_ENCRYPTION_KEY)
-      $secureYaml = ConvertFrom-SecureString (ConvertTo-SecureString $yaml -AsPlainText) -Key $keyBytes
-      ("RESOLVED_SECRETS={0}" -f $secureYaml) | Out-File -Append $env:GITHUB_OUTPUT
+      if ([string]::IsNullOrEmpty($env:SECRETS_ENCRYPTION_KEY)) {
+          Write-Warning "Secrets cannot processed due to the encryption key not being provided. The calling workflow should ensure that the 'secretsEncryptionKey' input is set. The value is typically stored in the SHARED_WORKFLOW_KEY secret."
+      }
+      else {
+        $srcSecrets = @'
+        ${{ inputs.secretsYaml }}
+        '@
+        Write-Host "REQUIRED_SECRETS: $srcSecrets"
+        $yaml = ConvertFrom-Yaml $srcSecrets | ConvertTo-Yaml
+        Write-Host "yaml: $yaml"
+        $keyBytes = [Convert]::FromBase64String($env:SECRETS_ENCRYPTION_KEY)
+        $secureYaml = ConvertFrom-SecureString (ConvertTo-SecureString $yaml -AsPlainText) -Key $keyBytes
+        ("RESOLVED_SECRETS={0}" -f $secureYaml) | Out-File -Append $env:GITHUB_OUTPUT
+      }
     shell: pwsh
     env:
       SECRETS_ENCRYPTION_KEY: ${{ inputs.secretsEncryptionKey }}

--- a/actions/prepare-env-vars-and-secrets/action.yml
+++ b/actions/prepare-env-vars-and-secrets/action.yml
@@ -24,7 +24,8 @@ runs:
   - id: installPsYaml
     name: Install PowerShell YAML module
     run: |
-      Install-Module Powershell-yaml -Scope CurrentUser -Force -Verbose
+      Install-Module Powershell-yaml -Scope CurrentUser -Force -Verbose:$false
+      Import-Module Powershell-yaml -Verbose:$false
     shell: pwsh 
   - id: prepareEnvVars
     name: Prepare Environment Variables
@@ -42,7 +43,6 @@ runs:
   - id: prepareSecrets
     name: Prepare Secrets
     run: |
-      Import-Module Powershell-yaml
       $srcSecrets = @'
       ${{ inputs.secretsYaml }}
       '@

--- a/actions/run-build-process/action.yml
+++ b/actions/run-build-process/action.yml
@@ -64,6 +64,9 @@ inputs:
   sbomOutputStorageContainerName:
     description: 'The name of the storage container where the SBOM output will be stored'
     required: false
+  secretsEncryptionKey:
+    description: A string representing the shared secret used to encrypt the secrets YAML object.
+    required: true
 
 outputs:
   semver:
@@ -86,11 +89,11 @@ runs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/secrets-passing
       with: 
         environmentVariablesYamlBase64: ${{ inputs.buildEnv}}
         secretsYamlBase64: ${{ inputs.buildSecrets}}
-        # secretsEncryptionKey: ${{ secrets.WORKFLOW_SHARED_KEY }}
+        secretsEncryptionKey: ${{ inputs.secretsEncryptionKey }}
     - name: Set defaults
       id: set_defaults
       run: |

--- a/actions/run-build-process/action.yml
+++ b/actions/run-build-process/action.yml
@@ -66,7 +66,7 @@ inputs:
     required: false
   secretsEncryptionKey:
     description: A string representing the shared secret used to encrypt the secrets YAML object.
-    required: true
+    required: false
 
 outputs:
   semver:

--- a/actions/run-build-process/action.yml
+++ b/actions/run-build-process/action.yml
@@ -89,7 +89,7 @@ runs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/secrets-passing
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
       with: 
         environmentVariablesYamlBase64: ${{ inputs.buildEnv}}
         secretsYamlBase64: ${{ inputs.buildSecrets}}

--- a/actions/run-build-process/action.yml
+++ b/actions/run-build-process/action.yml
@@ -90,6 +90,7 @@ runs:
       with: 
         environmentVariablesYamlBase64: ${{ inputs.buildEnv}}
         secretsYamlBase64: ${{ inputs.buildSecrets}}
+        # secretsEncryptionKey: ${{ secrets.WORKFLOW_SHARED_KEY }}
     - name: Set defaults
       id: set_defaults
       run: |

--- a/actions/run-build-process/action.yml
+++ b/actions/run-build-process/action.yml
@@ -89,7 +89,7 @@ runs:
       with:
         fetch-depth: 0
         submodules: true
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@feature/secrets-passing
       with: 
         environmentVariablesYamlBase64: ${{ inputs.buildEnv}}
         secretsYamlBase64: ${{ inputs.buildSecrets}}

--- a/actions/set-env-vars-and-secrets/action.yml
+++ b/actions/set-env-vars-and-secrets/action.yml
@@ -18,6 +18,7 @@ runs:
     name: Install PowerShell YAML module
     run: |
       Install-Module Powershell-yaml -Scope CurrentUser -Force -Verbose
+      Import-Module Powershell-yaml -Verbose:$false
     shell: pwsh   
   - id: setEnvironmentVariables
     name: Set Environment Variables
@@ -33,8 +34,7 @@ runs:
   - id: setSecrets
     name: Set Secrets
     run: |
-      if ($env:INCOMING_ENV_VARS) {
-        Import-Module Powershell-yaml
+      if (![string]::IsNullOrEmpty($env:INCOMING_SECRETS)) {
         $keyBytes = [Convert]::FromBase64String($env:SECRETS_ENCRYPTION_KEY)
         $secretsYaml = ConvertFrom-SecureString (ConvertTo-SecureString $env:INCOMING_SECRETS -Key $keyBytes) -AsPlainText
         $secrets = ConvertFrom-Yaml $secretsYaml

--- a/actions/set-env-vars-and-secrets/action.yml
+++ b/actions/set-env-vars-and-secrets/action.yml
@@ -35,6 +35,7 @@ runs:
     name: Set Secrets
     run: |
       if ([string]::IsNullOrEmpty($env:SECRETS_ENCRYPTION_KEY)) {
+        Write-Host "::warning title=Secrets skipped::Secrets cannot processed due to the encryption key not being provided. The calling workflow should ensure that the 'secretsEncryptionKey' input is set. The value is typically stored in the SHARED_WORKFLOW_KEY secret."
         Write-Warning "Secrets cannot processed due to the encryption key not being provided. The calling workflow should ensure that the 'secretsEncryptionKey' input is set. The value is typically stored in the SHARED_WORKFLOW_KEY secret."
       }
       elseif (![string]::IsNullOrEmpty($env:INCOMING_SECRETS)) {

--- a/actions/set-env-vars-and-secrets/action.yml
+++ b/actions/set-env-vars-and-secrets/action.yml
@@ -3,10 +3,13 @@ description: 'Injects environment variables and secrets passed as YAML-formatted
 inputs:
   environmentVariablesYamlBase64:
     description: A Base64-encoded YAML object representing environment variables that need to be set for the current job.
-    default: 'ewB9AA=='   # '{}'
+    default: 'ewB9AA=='   # '{}' TODO!
   secretsYamlBase64:
     description: A Base64-encoded YAML object representing secrets that need to be set for the current job.
-    default: 'ewB9AA=='   # '{}'
+    default: 'ewB9AA=='   # '{}' TODO!
+  # secretsEncryptionKey:
+  #   description: A string representing the shared secret used to decrypt the secrets YAML object.
+  #   required: true
 
 runs:
   using: "composite"
@@ -31,8 +34,8 @@ runs:
     name: Set Secrets
     run: |
       Import-Module Powershell-yaml
-      Write-Host ("::add-mask::{0}" -f $env:INCOMING_SECRETS)
-      $secretsYaml = [System.Text.Encoding]::Unicode.GetString([Convert]::FromBase64String($env:INCOMING_SECRETS))
+      $keyBytes = [Convert]::FromBase64String($env:SECRETS_ENCRYPTION_KEY)
+      $secretsYaml = ConvertFrom-SecureString (ConvertTo-SecureString $env:INCOMING_SECRETS -Key $keyBytes) -AsPlainText
       $secrets = ConvertFrom-Yaml $secretsYaml
       foreach ($secretName in $secrets.Keys) {
         ('{0}={1}' -f $secretName, $secrets[$secretName]) | Out-File -Append -FilePath $env:GITHUB_ENV
@@ -41,3 +44,4 @@ runs:
     shell: pwsh
     env:
       INCOMING_SECRETS: ${{ inputs.secretsYamlBase64 }}
+      SECRETS_ENCRYPTION_KEY: ${{ secrets.WORKFLOW_SHARED_KEY }}

--- a/actions/set-env-vars-and-secrets/action.yml
+++ b/actions/set-env-vars-and-secrets/action.yml
@@ -7,9 +7,9 @@ inputs:
   secretsYamlBase64:
     description: A Base64-encoded YAML object representing secrets that need to be set for the current job.
     default: 'ewB9AA=='   # '{}' TODO!
-  # secretsEncryptionKey:
-  #   description: A string representing the shared secret used to decrypt the secrets YAML object.
-  #   required: true
+  secretsEncryptionKey:
+    description: A string representing the shared secret used to decrypt the secrets YAML object.
+    required: true
 
 runs:
   using: "composite"
@@ -44,4 +44,4 @@ runs:
     shell: pwsh
     env:
       INCOMING_SECRETS: ${{ inputs.secretsYamlBase64 }}
-      SECRETS_ENCRYPTION_KEY: ${{ secrets.WORKFLOW_SHARED_KEY }}
+      SECRETS_ENCRYPTION_KEY: ${{ inputs.secretsEncryptionKey }}

--- a/actions/set-env-vars-and-secrets/action.yml
+++ b/actions/set-env-vars-and-secrets/action.yml
@@ -17,7 +17,7 @@ runs:
   - id: installPsYaml
     name: Install PowerShell YAML module
     run: |
-      Install-Module Powershell-yaml -Scope CurrentUser -Force -Verbose
+      Install-Module Powershell-yaml -Scope CurrentUser -Force -Verbose:$false
       Import-Module Powershell-yaml -Verbose:$false
     shell: pwsh   
   - id: setEnvironmentVariables

--- a/actions/set-env-vars-and-secrets/action.yml
+++ b/actions/set-env-vars-and-secrets/action.yml
@@ -34,18 +34,16 @@ runs:
   - id: setSecrets
     name: Set Secrets
     run: |
-      if (![string]::IsNullOrEmpty($env:INCOMING_SECRETS)) {
-        if ([string]::IsNullOrEmpty($env:SECRETS_ENCRYPTION_KEY)) {
-          Write-Warning "Secrets cannot processed due to the encryption key not being provided. The calling workflow should ensure that the 'secretsEncryptionKey' input is set. The value is typically stored in the SHARED_WORKFLOW_KEY secret."
-        }
-        else {
-          $keyBytes = [Convert]::FromBase64String($env:SECRETS_ENCRYPTION_KEY)
-          $secretsYaml = ConvertFrom-SecureString (ConvertTo-SecureString $env:INCOMING_SECRETS -Key $keyBytes) -AsPlainText
-          $secrets = ConvertFrom-Yaml $secretsYaml
-          foreach ($secretName in $secrets.Keys) {
-            ('{0}={1}' -f $secretName, $secrets[$secretName]) | Out-File -Append -FilePath $env:GITHUB_ENV
-            Write-Host ("::add-mask::{0}" -f $secrets[$secretName])
-          }
+      if ([string]::IsNullOrEmpty($env:SECRETS_ENCRYPTION_KEY)) {
+        Write-Warning "Secrets cannot processed due to the encryption key not being provided. The calling workflow should ensure that the 'secretsEncryptionKey' input is set. The value is typically stored in the SHARED_WORKFLOW_KEY secret."
+      }
+      elseif (![string]::IsNullOrEmpty($env:INCOMING_SECRETS)) {
+        $keyBytes = [Convert]::FromBase64String($env:SECRETS_ENCRYPTION_KEY)
+        $secretsYaml = ConvertFrom-SecureString (ConvertTo-SecureString $env:INCOMING_SECRETS -Key $keyBytes) -AsPlainText
+        $secrets = ConvertFrom-Yaml $secretsYaml
+        foreach ($secretName in $secrets.Keys) {
+          ('{0}={1}' -f $secretName, $secrets[$secretName]) | Out-File -Append -FilePath $env:GITHUB_ENV
+          Write-Host ("::add-mask::{0}" -f $secrets[$secretName])
         }
       }
     shell: pwsh

--- a/actions/set-env-vars-and-secrets/action.yml
+++ b/actions/set-env-vars-and-secrets/action.yml
@@ -9,7 +9,7 @@ inputs:
     required: false
   secretsEncryptionKey:
     description: A string representing the shared secret used to decrypt the secrets YAML object.
-    required: true
+    required: false
 
 runs:
   using: "composite"
@@ -35,12 +35,17 @@ runs:
     name: Set Secrets
     run: |
       if (![string]::IsNullOrEmpty($env:INCOMING_SECRETS)) {
-        $keyBytes = [Convert]::FromBase64String($env:SECRETS_ENCRYPTION_KEY)
-        $secretsYaml = ConvertFrom-SecureString (ConvertTo-SecureString $env:INCOMING_SECRETS -Key $keyBytes) -AsPlainText
-        $secrets = ConvertFrom-Yaml $secretsYaml
-        foreach ($secretName in $secrets.Keys) {
-          ('{0}={1}' -f $secretName, $secrets[$secretName]) | Out-File -Append -FilePath $env:GITHUB_ENV
-          Write-Host ("::add-mask::{0}" -f $secrets[$secretName])
+        if ([string]::IsNullOrEmpty($env:SECRETS_ENCRYPTION_KEY)) {
+          Write-Warning "Secrets cannot processed due to the encryption key not being provided. The calling workflow should ensure that the 'secretsEncryptionKey' input is set. The value is typically stored in the SHARED_WORKFLOW_KEY secret."
+        }
+        else {
+          $keyBytes = [Convert]::FromBase64String($env:SECRETS_ENCRYPTION_KEY)
+          $secretsYaml = ConvertFrom-SecureString (ConvertTo-SecureString $env:INCOMING_SECRETS -Key $keyBytes) -AsPlainText
+          $secrets = ConvertFrom-Yaml $secretsYaml
+          foreach ($secretName in $secrets.Keys) {
+            ('{0}={1}' -f $secretName, $secrets[$secretName]) | Out-File -Append -FilePath $env:GITHUB_ENV
+            Write-Host ("::add-mask::{0}" -f $secrets[$secretName])
+          }
         }
       }
     shell: pwsh

--- a/actions/set-env-vars-and-secrets/action.yml
+++ b/actions/set-env-vars-and-secrets/action.yml
@@ -3,10 +3,10 @@ description: 'Injects environment variables and secrets passed as YAML-formatted
 inputs:
   environmentVariablesYamlBase64:
     description: A Base64-encoded YAML object representing environment variables that need to be set for the current job.
-    default: 'ewB9AA=='   # '{}' TODO!
+    default: 'ewB9AA=='   # '{}'
   secretsYamlBase64:
     description: A Base64-encoded YAML object representing secrets that need to be set for the current job.
-    default: 'ewB9AA=='   # '{}' TODO!
+    required: false
   secretsEncryptionKey:
     description: A string representing the shared secret used to decrypt the secrets YAML object.
     required: true
@@ -33,13 +33,15 @@ runs:
   - id: setSecrets
     name: Set Secrets
     run: |
-      Import-Module Powershell-yaml
-      $keyBytes = [Convert]::FromBase64String($env:SECRETS_ENCRYPTION_KEY)
-      $secretsYaml = ConvertFrom-SecureString (ConvertTo-SecureString $env:INCOMING_SECRETS -Key $keyBytes) -AsPlainText
-      $secrets = ConvertFrom-Yaml $secretsYaml
-      foreach ($secretName in $secrets.Keys) {
-        ('{0}={1}' -f $secretName, $secrets[$secretName]) | Out-File -Append -FilePath $env:GITHUB_ENV
-        Write-Host ("::add-mask::{0}" -f $secrets[$secretName])
+      if ($env:INCOMING_ENV_VARS) {
+        Import-Module Powershell-yaml
+        $keyBytes = [Convert]::FromBase64String($env:SECRETS_ENCRYPTION_KEY)
+        $secretsYaml = ConvertFrom-SecureString (ConvertTo-SecureString $env:INCOMING_SECRETS -Key $keyBytes) -AsPlainText
+        $secrets = ConvertFrom-Yaml $secretsYaml
+        foreach ($secretName in $secrets.Keys) {
+          ('{0}={1}' -f $secretName, $secrets[$secretName]) | Out-File -Append -FilePath $env:GITHUB_ENV
+          Write-Host ("::add-mask::{0}" -f $secrets[$secretName])
+        }
       }
     shell: pwsh
     env:


### PR DESCRIPTION
Rather than masking the Base64 value representing the build-specific secrets, we now encrypt the Base64 value so masking is no longer required.

A new Organisational secret is used to provide the encryption key.