### PR TITLE
Support large test result files

### DIFF
--- a/.github/workflows/scripted-build-matrix-pipeline.yml
+++ b/.github/workflows/scripted-build-matrix-pipeline.yml
@@ -312,6 +312,7 @@ jobs:
         nunit_files: "*TestResults.xml"    # produced by Pester
         trx_files: "**/test-results_*.trx" # produced by dotnet test
         junit_files: "**/*-test-results.xml" # produced by PyTest & Behave
+        large_files: true
     - name: Publish Test Results (Windows)
       uses: EnricoMi/publish-unit-test-result-action/windows@170bf24d20d201b842d7a52403b73ed297e6645b   # v2.18.0
       if: always() && steps.check_os.outputs.RUNNEROS == 'windows'
@@ -319,6 +320,7 @@ jobs:
         nunit_files: "*TestResults.xml"    # produced by Pester
         trx_files: "**/test-results_*.trx" # produced by dotnet test
         junit_files: "**/*-test-results.xml" # produced by PyTest & Behave
+        large_files: true
 
   package:
     needs:

--- a/.github/workflows/scripted-build-matrix-pipeline.yml
+++ b/.github/workflows/scripted-build-matrix-pipeline.yml
@@ -101,6 +101,11 @@ on:
         required: false
         default: windows-latest
         type: string
+      largeTestResultFiles:
+        description: When true, the publish-unit-test-result-action will be configured to handle large test result files.
+        required: false
+        default: true # The performance impact of this seems small, and we believe there is no behaviour change, so we default to large file support.
+        type: boolean
 
     secrets:
       compilePhaseAzureCredentials:
@@ -312,7 +317,7 @@ jobs:
         nunit_files: "*TestResults.xml"    # produced by Pester
         trx_files: "**/test-results_*.trx" # produced by dotnet test
         junit_files: "**/*-test-results.xml" # produced by PyTest & Behave
-        large_files: true
+        large_files: ${{ inputs.largeTestResultFiles }}
     - name: Publish Test Results (Windows)
       uses: EnricoMi/publish-unit-test-result-action/windows@170bf24d20d201b842d7a52403b73ed297e6645b   # v2.18.0
       if: always() && steps.check_os.outputs.RUNNEROS == 'windows'
@@ -320,7 +325,7 @@ jobs:
         nunit_files: "*TestResults.xml"    # produced by Pester
         trx_files: "**/test-results_*.trx" # produced by dotnet test
         junit_files: "**/*-test-results.xml" # produced by PyTest & Behave
-        large_files: true
+        large_files: ${{ inputs.largeTestResultFiles }}
 
   package:
     needs:

--- a/.github/workflows/scripted-build-pipeline.yml
+++ b/.github/workflows/scripted-build-pipeline.yml
@@ -76,6 +76,11 @@ on:
         required: false
         default: ubuntu-latest
         type: string
+      largeTestResultFiles:
+        description: When true, the publish-unit-test-result-action will be configured to handle large test result files.
+        required: false
+        default: true # The performance impact of this seems small, and we believe there is no behaviour change, so we default to large file support.
+        type: boolean
 
     secrets:
       compilePhaseAzureCredentials:
@@ -281,6 +286,7 @@ jobs:
         nunit_files: "*TestResults.xml"    # produced by Pester
         trx_files: "**/test-results_*.trx" # produced by dotnet test
         junit_files: "**/*-test-results.xml" # produced by PyTest & Behave
+        large_files: ${{ inputs.largeTestResultFiles }}
     - name: Publish Test Results (Windows)
       uses: EnricoMi/publish-unit-test-result-action/windows@170bf24d20d201b842d7a52403b73ed297e6645b   # v2.18.0
       if: always() && steps.check_os.outputs.RUNNEROS == 'windows'
@@ -288,6 +294,7 @@ jobs:
         nunit_files: "*TestResults.xml"    # produced by Pester
         trx_files: "**/test-results_*.trx" # produced by dotnet test
         junit_files: "**/*-test-results.xml" # produced by PyTest & Behave
+        large_files: ${{ inputs.largeTestResultFiles }}
 
   package:
     needs:

--- a/actions/run-build-process/action.yml
+++ b/actions/run-build-process/action.yml
@@ -40,6 +40,10 @@ inputs:
     description: The operating system to run all stages of this workflow.
     required: false
     default: ubuntu-latest
+  largeTestResultFiles:
+    description: When true, the publish-unit-test-result-action will be configured to handle large test result files.
+    required: false
+    default: 'true' # The performance impact of this seems small, and we believe there is no behaviour change, so we default to large file support.
   # Secrets
   buildAzureCredentials:
     description: A secret containing the Azure credentials required to run the build process.
@@ -210,6 +214,7 @@ runs:
         nunit_files: "*TestResults.xml"    # produced by Pester
         trx_files: "**/test-results_*.trx" # produced by dotnet test
         junit_files: "**/*-test-results.xml" # produced by PyTest & Behave
+        large_files: ${{ inputs.largeTestResultFiles == 'true' }}
     - name: Publish Test Results (Windows)
       uses: EnricoMi/publish-unit-test-result-action/windows@170bf24d20d201b842d7a52403b73ed297e6645b   # v2.18.0
       if: always() && steps.check_os.outputs.RUNNEROS == 'windows'
@@ -217,3 +222,4 @@ runs:
         nunit_files: "*TestResults.xml"    # produced by Pester
         trx_files: "**/test-results_*.trx" # produced by dotnet test
         junit_files: "**/*-test-results.xml" # produced by PyTest & Behave
+        large_files: ${{ inputs.largeTestResultFiles == 'true' }}


### PR DESCRIPTION
In `Corvus.JsonSchema` we routinely saw test result publication fail because of the large `.trx` files produced in that project.

The GitHub Action we're using has a `large_files` setting that avoids this problem.

This change enables the use of that by default, but provides a new setting that enables the old behaviour to be reinstated. We have made the new behaviour the default because as far as we can tell, there is no behaviour change, and if there is a performance cost, it is too small for us to detect in the overall cost of a build.