### PR TITLE
Enable git 'longpath' support by default

### DIFF
--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -158,6 +158,9 @@ jobs:
         EOF
         echo "is_release_pending : ${{ steps.get_release_pending_pr_list.outputs.is_release_pending }}"
 
+    - name: Enable long paths
+      run: git config --global core.longpaths true
+
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
     - name: Read pr-autoflow configuration
       id: get_pr_autoflow_config
@@ -210,6 +213,9 @@ jobs:
     - uses: actions/setup-dotnet@3951f0dfe7a07e2313ec93c75700083e2005cbab    # v4.3.0
       with:
         dotnet-version: '6.x'
+
+    - name: Enable long paths
+      run: git config --global core.longpaths true
 
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       with:

--- a/.github/workflows/ci-composite-action.yml
+++ b/.github/workflows/ci-composite-action.yml
@@ -37,6 +37,8 @@ jobs:
       preReleaseTag: ${{ steps.run_build.outputs.preReleaseTag }}
 
     steps:
+    - name: Enable long paths
+      run: git config --global core.longpaths true
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       with:
         fetch-depth: 0

--- a/.github/workflows/ci-matrix.yml
+++ b/.github/workflows/ci-matrix.yml
@@ -40,6 +40,8 @@ jobs:
       RESOLVED_ENV_VARS: ${{ steps.prepareEnvVarsAndSecrets.outputs.environmentVariablesYamlBase64 }}
       RESOLVED_SECRETS: ${{ steps.prepareEnvVarsAndSecrets.outputs.secretsYamlBase64 }}
     steps:
+    - name: Enable long paths
+      run: git config --global core.longpaths true
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         fetch-depth: 0

--- a/.github/workflows/ci-single-job.yml
+++ b/.github/workflows/ci-single-job.yml
@@ -35,6 +35,8 @@ jobs:
       RESOLVED_ENV_VARS: ${{ steps.prepareEnvVarsAndSecrets.outputs.environmentVariablesYamlBase64 }}
       RESOLVED_SECRETS: ${{ steps.prepareEnvVarsAndSecrets.outputs.secretsYamlBase64 }}
     steps:
+    - name: Enable long paths
+      run: git config --global core.longpaths true
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         fetch-depth: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
       RESOLVED_ENV_VARS: ${{ steps.prepareEnvVarsAndSecrets.outputs.environmentVariablesYamlBase64 }}
       RESOLVED_SECRETS: ${{ steps.prepareEnvVarsAndSecrets.outputs.secretsYamlBase64 }}
     steps:
+    - name: Enable long paths
+      run: git config --global core.longpaths true
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         fetch-depth: 0

--- a/.github/workflows/dependabot_approve_and_label.yml
+++ b/.github/workflows/dependabot_approve_and_label.yml
@@ -23,6 +23,8 @@ jobs:
       is_auto_release_candidate: ${{ steps.parse_dependabot_pr_autorelease.outputs.is_interesting_package }}
       semver_increment: ${{ steps.parse_dependabot_pr_automerge.outputs.semver_increment }}
     steps:
+      - name: Enable long paths
+        run: git config --global core.longpaths true
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       - name: Read pr-autoflow configuration
         id: get_pr_autoflow_config

--- a/.github/workflows/scripted-build-matrix-pipeline.yml
+++ b/.github/workflows/scripted-build-matrix-pipeline.yml
@@ -142,6 +142,8 @@ jobs:
       preReleaseTag: ${{ steps.run_compile.outputs.preReleaseTag }}
 
     steps:
+    - name: Enable long paths
+      run: git config --global core.longpaths true
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         fetch-depth: 0
@@ -210,6 +212,8 @@ jobs:
       matrix: ${{ fromJson(inputs.testPhaseMatrixJson) }}
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Enable long paths
+      run: git config --global core.longpaths true
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       with:
         fetch-depth: 0
@@ -326,6 +330,8 @@ jobs:
     name: Package
     runs-on: ${{ inputs.packagePhaseRunnerOs }}
     steps:
+    - name: Enable long paths
+      run: git config --global core.longpaths true
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       with:
         fetch-depth: 0
@@ -384,6 +390,8 @@ jobs:
       contents: write
       packages: write
     steps:
+    - name: Enable long paths
+      run: git config --global core.longpaths true
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683   #v4.2.2
       with:
         fetch-depth: 0

--- a/.github/workflows/scripted-build-pipeline.yml
+++ b/.github/workflows/scripted-build-pipeline.yml
@@ -117,6 +117,8 @@ jobs:
       preReleaseTag: ${{ steps.run_compile.outputs.preReleaseTag }}
 
     steps:
+    - name: Enable long paths
+      run: git config --global core.longpaths true
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       with:
         fetch-depth: 0
@@ -181,6 +183,8 @@ jobs:
     name: Test
     runs-on: ${{ inputs.runsOn }}
     steps:
+    - name: Enable long paths
+      run: git config --global core.longpaths true
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         fetch-depth: 0
@@ -295,6 +299,8 @@ jobs:
     name: Package
     runs-on: ${{ inputs.runsOn }}
     steps:
+    - name: Enable long paths
+      run: git config --global core.longpaths true
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       with:
         fetch-depth: 0
@@ -352,6 +358,8 @@ jobs:
       contents: write
       packages: write
     steps:
+    - name: Enable long paths
+      run: git config --global core.longpaths true
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683   #v4.2.2
       with:
         fetch-depth: 0

--- a/actions/run-build-process/action.yml
+++ b/actions/run-build-process/action.yml
@@ -87,6 +87,7 @@ runs:
   steps:
     - name: Enable long paths
       run: git config --global core.longpaths true
+      shell: bash
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       with:
         fetch-depth: 0

--- a/actions/run-build-process/action.yml
+++ b/actions/run-build-process/action.yml
@@ -85,6 +85,8 @@ outputs:
 runs:
   using: "composite"  
   steps:
+    - name: Enable long paths
+      run: git config --global core.longpaths true
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       with:
         fetch-depth: 0

--- a/actions/run-build-process/action.yml
+++ b/actions/run-build-process/action.yml
@@ -40,16 +40,6 @@ inputs:
     description: The operating system to run all stages of this workflow.
     required: false
     default: ubuntu-latest
-  # Secrets
-  buildAzureCredentials:
-    description: A secret containing the Azure credentials required to run the build process.
-    required: false
-  buildSecrets:
-    description: A YAML string representing a dictionary of secrets required when running the 'compile' stage of this workflow.
-    required: false
-  token:
-    description: 'A GitHub token'
-    required: true
   codeCoverageSummaryDir:
     description: 'The directory where the code coverage summary file is stored'
     required: false
@@ -64,6 +54,16 @@ inputs:
   sbomOutputStorageContainerName:
     description: 'The name of the storage container where the SBOM output will be stored'
     required: false
+  # Secrets
+  buildAzureCredentials:
+    description: A secret containing the Azure credentials required to run the build process.
+    required: false
+  buildSecrets:
+    description: A YAML string representing a dictionary of secrets required when running the 'compile' stage of this workflow.
+    required: false
+  token:
+    description: 'A GitHub token'
+    required: true
   secretsEncryptionKey:
     description: A string representing the shared secret used to encrypt the secrets YAML object.
     required: false
@@ -102,7 +102,7 @@ runs:
       run: |
         echo "inputs: ${{ toJson(inputs) }}"
         echo "ref: ${{ github.ref }}"
-        echo "CODE_COVERAGE_SUMMARY_FILE=${{ inputs.codeCoverageSummaryDir || '_codeCoverage' }}" >> $GITHUB_OUTPUT
+        echo "CODE_COVERAGE_SUMMARY_DIR=${{ inputs.codeCoverageSummaryDir || '_codeCoverage' }}" >> $GITHUB_OUTPUT
         echo "CODE_COVERAGE_SUMMARY_FILE=${{ inputs.codeCoverageSummaryFile || 'SummaryGithub.md' }}" >> $GITHUB_OUTPUT
         echo "DEFAULT_BUILD_TASKS=${{ (inputs.forcePublish == 'true' || startsWith(github.ref, 'refs/tags/')) && 'FullBuildAndPublish' || 'FullBuild' }}" >> $GITHUB_OUTPUT
       shell: bash

--- a/actions/vellum-site-build/action.yml
+++ b/actions/vellum-site-build/action.yml
@@ -14,6 +14,7 @@ runs:
   steps:
   - name: Enable long paths
     run: git config --global core.longpaths true
+    shell: bash
   - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
   - name: Get cached NPM modules

--- a/actions/vellum-site-build/action.yml
+++ b/actions/vellum-site-build/action.yml
@@ -12,6 +12,8 @@ inputs:
 runs:
   using: "composite"
   steps:
+  - name: Enable long paths
+    run: git config --global core.longpaths true
   - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
   - name: Get cached NPM modules


### PR DESCRIPTION
Adds default behaviour for avoiding MAXPATH issues.

Also fixes a bug that was blocking functionality that surfaces code coverage results as PR annotations.