### PR TITLE
Add optional post-compile parallel job to scripted-build-matrix-pipeline

### DIFF
--- a/.github/workflows/scripted-build-matrix-pipeline.yml
+++ b/.github/workflows/scripted-build-matrix-pipeline.yml
@@ -28,9 +28,19 @@ on:
         description: A JSON object representing the environment variables required when running the 'compile' stage of this workflow.
         required: false
         type: string
+      compilePhaseTasks:
+        description: The tasks that need to be run as part of the 'compile' stage, formatted as a comma-delimited string (e.g. 'Build' or 'Build,Analysis').
+        required: false
+        default: 'Build,Analysis'
+        type: string
       testPhaseEnv:
         description: A JSON object representing the environment variables required when running the 'test' stage of this workflow.
         required: false
+        type: string
+      testPhaseTasks:
+        description: The tasks that need to be run as part of the 'test' stage, formatted as a comma-delimited string (e.g. 'Test' or 'Test,TestReport').
+        required: false
+        default: 'Test'
         type: string
       testArtifactName:
         description: If set, during the test phase, uploads a GitHub artifact with the provided name (path must be specified in `artifactPath`)
@@ -44,9 +54,19 @@ on:
         description: A JSON object representing the environment variables required when running the 'package' stage of this workflow.
         required: false
         type: string
+      packagePhaseTasks:
+        description: The tasks that need to be run as part of the 'package' stage, formatted as a comma-delimited string.
+        required: false
+        default: 'Package'
+        type: string
       publishPhaseEnv:
         description: A JSON object representing the environment variables required when running the 'publish' stage of this workflow.
         required: false
+        type: string
+      publishPhaseTasks:
+        description: The tasks that need to be run as part of the 'publish' stage, formatted as a comma-delimited string.
+        required: false
+        default: 'Publish'
         type: string
       publishArtifactName:
         description: If set, during the publish phase, uploads a GitHub artifact with the provided name (path must be specified in `artifactPath`)
@@ -101,11 +121,6 @@ on:
         required: false
         default: windows-latest
         type: string
-      postCompileScript:
-        description: Optional PowerShell script to run in a parallel job after compile completes (alongside test and package). When set, a 'post-compile' job is added that restores the compile cache and runs this script.
-        required: false
-        default: ''
-        type: string
       postCompileRunnerOs:
         description: The operating system to run the optional 'post-compile' job on.
         required: false
@@ -114,6 +129,11 @@ on:
       postCompilePhaseEnv:
         description: A JSON object representing the environment variables required when running the optional 'post-compile' job.
         required: false
+        type: string
+      postCompilePhaseTasks:
+        description: The tasks that need to be run as part of the 'post-compile' stage, formatted as a comma-delimited string.
+        required: false
+        default: 'postCompile'
         type: string
       postCompileArtifactName:
         description: If set, during the post-compile phase, uploads a GitHub artifact with the provided name (path must be specified in `postCompileArtifactPath`).
@@ -183,7 +203,7 @@ jobs:
         netSdkVersion: ${{ inputs.netSdkVersion }}
         additionalNetSdkVersion: ${{ inputs.additionalNetSdkVersion }}
         pythonVersion: ${{ inputs.pythonVersion }}
-        tasks: 'Build,Analysis'
+        tasks: ${{ inputs.compilePhaseTasks }}
         configuration: ${{ inputs.configuration }}
         outputCacheKeySuffix: compile
         outputCachePaths: |
@@ -228,7 +248,7 @@ jobs:
         buildScriptPath: ${{ inputs.buildScriptPath }}
         netSdkVersion: ${{ inputs.netSdkVersion }}
         additionalNetSdkVersion: ${{ inputs.additionalNetSdkVersion }}
-        tasks: 'Test'
+        tasks: ${{ inputs.testPhaseTasks }}
         configuration: ${{ inputs.configuration }}
         inputCacheKeySuffix: compile
         inputCachePaths: |
@@ -328,7 +348,7 @@ jobs:
         buildScriptPath: ${{ inputs.buildScriptPath }}
         netSdkVersion: ${{ inputs.netSdkVersion }}
         additionalNetSdkVersion: ${{ inputs.additionalNetSdkVersion }}
-        tasks: 'Package'
+        tasks: ${{ inputs.packagePhaseTasks }}
         configuration: ${{ inputs.configuration }}
         inputCacheKeySuffix: compile
         inputCachePaths: |
@@ -355,36 +375,24 @@ jobs:
         additionalEnvVars: ${{ inputs.postCompilePhaseEnv}}
         additionalSecrets: ${{ secrets.postCompilePhaseSecrets }}
         secretsEncryptionKey: ${{ secrets.secretsEncryptionKey }}
-    - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7   # v5.2.0
-      name: Install .NET Core SDK ${{ inputs.netSdkVersion }}
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@main
+      id: run_post_compile
       with:
-        dotnet-version: '${{ inputs.netSdkVersion }}'
-    - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7   # v5.2.0
-      if: inputs.additionalNetSdkVersion != ''
-      name: Install .NET Core SDK ${{ inputs.additionalNetSdkVersion }}
-      with:
-        dotnet-version: '${{ inputs.additionalNetSdkVersion }}'
-    - name: Restore compile cache
-      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae    # v5.0.5
-      id: cache_restore
-      with:
-        path: |
+        displayName: Post-Compile
+        buildScriptPath: ${{ inputs.buildScriptPath }}
+        netSdkVersion: ${{ inputs.netSdkVersion }}
+        additionalNetSdkVersion: ${{ inputs.additionalNetSdkVersion }}
+        pythonVersion: ${{ inputs.pythonVersion }}
+        tasks: ${{ inputs.postCompilePhaseTasks }}
+        configuration: ${{ inputs.configuration }}
+        inputCacheKeySuffix: compile
+        outputCacheKeySuffix: postcompile
+        outputCachePaths: |
           .nuget-packages
           Solutions
           solutions
           ${{ inputs.additionalCachePaths }}
-        key: build-state-${{ github.run_id }}-compile
-        enableCrossOsArchive: ${{ inputs.enableCrossOsCaching }}
-    - name: Ensure compile cache restored
-      if: steps.cache_restore.outputs.cache-hit == 'false'
-      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3   # v9.0.0
-      with:
-        script: |
-          core.setFailed('Aborting post-compile: GHA cache restore failure of required compile state')
-    - name: Run post-compile script
-      run: pwsh -File ${{ inputs.postCompileScript }}
-      env:
-        NUGET_PACKAGES: ${{ github.workspace }}/.nuget-packages
+        enableCrossOsCaching: ${{ inputs.enableCrossOsCaching}}
     - name: Upload artifact
       if: inputs.postCompileArtifactName != '' && inputs.postCompileArtifactPath != ''
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a    # v7.0.1
@@ -418,7 +426,7 @@ jobs:
         buildScriptPath: ${{ inputs.buildScriptPath }}
         netSdkVersion: ${{ inputs.netSdkVersion }}
         additionalNetSdkVersion: ${{ inputs.additionalNetSdkVersion }}
-        tasks: 'Publish'
+        tasks: ${{ inputs.publishPhaseTasks }}
         inputCacheKeySuffix: package
         inputCachePaths: |
           _packages

--- a/.github/workflows/scripted-build-matrix-pipeline.yml
+++ b/.github/workflows/scripted-build-matrix-pipeline.yml
@@ -133,7 +133,7 @@ on:
       postCompilePhaseTasks:
         description: The tasks that need to be run as part of the 'post-compile' stage, formatted as a comma-delimited string.
         required: false
-        default: 'postCompile'
+        default: ''
         type: string
       postCompileArtifactName:
         description: If set, during the post-compile phase, uploads a GitHub artifact with the provided name (path must be specified in `postCompileArtifactPath`).

--- a/.github/workflows/scripted-build-matrix-pipeline.yml
+++ b/.github/workflows/scripted-build-matrix-pipeline.yml
@@ -189,7 +189,7 @@ jobs:
       preReleaseTag: ${{ steps.run_compile.outputs.preReleaseTag }}
 
     steps:
-    - uses: ./actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
       with:
         azureCredentials: ${{ secrets.compilePhaseAzureCredentials }}
         additionalEnvVars: ${{ inputs.compilePhaseEnv}}
@@ -236,7 +236,7 @@ jobs:
       matrix: ${{ fromJson(inputs.testPhaseMatrixJson) }}
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: ./actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
+    - uses: ./actions/endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
       with:
         azureCredentials: ${{ secrets.testPhaseAzureCredentials }}
         additionalEnvVars: ${{ inputs.testPhaseEnv}}
@@ -340,7 +340,7 @@ jobs:
     name: Package
     runs-on: ${{ inputs.packagePhaseRunnerOs }}
     steps:
-    - uses: ./actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
+    - uses: ./actions/endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
       with:
         azureCredentials: ${{ secrets.packagePhaseAzureCredentials }}
         additionalEnvVars: ${{ inputs.packagePhaseEnv}}
@@ -373,7 +373,7 @@ jobs:
     if: inputs.postCompileScript != ''
     runs-on: ${{ inputs.postCompileRunnerOs }}
     steps:
-    - uses: ./actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
+    - uses: ./actions/endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
       with:
         azureCredentials: ${{ secrets.postCompilePhaseAzureCredentials }}
         additionalEnvVars: ${{ inputs.postCompilePhaseEnv}}
@@ -418,7 +418,7 @@ jobs:
       contents: write
       packages: write
     steps:
-    - uses: ./actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
+    - uses: ./actions/endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
       with:
         azureCredentials: ${{ secrets.publishPhaseAzureCredentials }}
         additionalEnvVars: ${{ inputs.publishPhaseEnv}}

--- a/.github/workflows/scripted-build-matrix-pipeline.yml
+++ b/.github/workflows/scripted-build-matrix-pipeline.yml
@@ -189,7 +189,7 @@ jobs:
       preReleaseTag: ${{ steps.run_compile.outputs.preReleaseTag }}
 
     steps:
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@main
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
       with:
         azureCredentials: ${{ secrets.compilePhaseAzureCredentials }}
         additionalEnvVars: ${{ inputs.compilePhaseEnv}}
@@ -236,7 +236,7 @@ jobs:
       matrix: ${{ fromJson(inputs.testPhaseMatrixJson) }}
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@main
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
       with:
         azureCredentials: ${{ secrets.testPhaseAzureCredentials }}
         additionalEnvVars: ${{ inputs.testPhaseEnv}}
@@ -340,7 +340,7 @@ jobs:
     name: Package
     runs-on: ${{ inputs.packagePhaseRunnerOs }}
     steps:
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@main
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
       with:
         azureCredentials: ${{ secrets.packagePhaseAzureCredentials }}
         additionalEnvVars: ${{ inputs.packagePhaseEnv}}
@@ -373,7 +373,7 @@ jobs:
     if: inputs.postCompilePhaseTasks != ''
     runs-on: ${{ inputs.postCompileRunnerOs }}
     steps:
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@main
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
       with:
         azureCredentials: ${{ secrets.postCompilePhaseAzureCredentials }}
         additionalEnvVars: ${{ inputs.postCompilePhaseEnv}}
@@ -423,7 +423,7 @@ jobs:
       contents: write
       packages: write
     steps:
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@main
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
       with:
         azureCredentials: ${{ secrets.publishPhaseAzureCredentials }}
         additionalEnvVars: ${{ inputs.publishPhaseEnv}}

--- a/.github/workflows/scripted-build-matrix-pipeline.yml
+++ b/.github/workflows/scripted-build-matrix-pipeline.yml
@@ -390,6 +390,11 @@ jobs:
         tasks: ${{ inputs.postCompilePhaseTasks }}
         configuration: ${{ inputs.configuration }}
         inputCacheKeySuffix: compile
+        inputCachePaths: |
+          .nuget-packages
+          Solutions
+          solutions
+          ${{ inputs.additionalCachePaths }}
         outputCacheKeySuffix: postcompile
         outputCachePaths: |
           .nuget-packages

--- a/.github/workflows/scripted-build-matrix-pipeline.yml
+++ b/.github/workflows/scripted-build-matrix-pipeline.yml
@@ -319,16 +319,20 @@ jobs:
       uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040   # v2.23.0
       if: always() && steps.check_os.outputs.RUNNEROS == 'linux'
       with:
-        nunit_files: "*TestResults.xml"    # produced by Pester
-        trx_files: "**/test-results_*.trx" # produced by dotnet test
-        junit_files: "**/*-test-results.xml" # produced by PyTest & Behave
+        # Look for test results produced by Pester, VSTest/MTP & PyTest/Behave
+        files: |
+          TestResults.xml
+          **/test-results*.trx
+          **/*-test-results.xml
     - name: Publish Test Results (Windows)
       uses: EnricoMi/publish-unit-test-result-action/windows@c950f6fb443cb5af20a377fd0dfaa78838901040   # v2.23.0
       if: always() && steps.check_os.outputs.RUNNEROS == 'windows'
       with:
-        nunit_files: "*TestResults.xml"    # produced by Pester
-        trx_files: "**/test-results_*.trx" # produced by dotnet test
-        junit_files: "**/*-test-results.xml" # produced by PyTest & Behave
+        # Look for test results produced by Pester, VSTest/MTP & PyTest/Behave
+        files: |
+          TestResults.xml
+          **/test-results*.trx
+          **/*-test-results.xml
 
   package:
     needs:

--- a/.github/workflows/scripted-build-matrix-pipeline.yml
+++ b/.github/workflows/scripted-build-matrix-pipeline.yml
@@ -370,7 +370,7 @@ jobs:
     needs:
     - compile
     name: Post-Compile
-    if: inputs.postCompileScript != ''
+    if: inputs.postCompilePhaseTasks != ''
     runs-on: ${{ inputs.postCompileRunnerOs }}
     steps:
     - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job

--- a/.github/workflows/scripted-build-matrix-pipeline.yml
+++ b/.github/workflows/scripted-build-matrix-pipeline.yml
@@ -236,7 +236,7 @@ jobs:
       matrix: ${{ fromJson(inputs.testPhaseMatrixJson) }}
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: ./actions/endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
       with:
         azureCredentials: ${{ secrets.testPhaseAzureCredentials }}
         additionalEnvVars: ${{ inputs.testPhaseEnv}}
@@ -340,7 +340,7 @@ jobs:
     name: Package
     runs-on: ${{ inputs.packagePhaseRunnerOs }}
     steps:
-    - uses: ./actions/endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
       with:
         azureCredentials: ${{ secrets.packagePhaseAzureCredentials }}
         additionalEnvVars: ${{ inputs.packagePhaseEnv}}
@@ -373,7 +373,7 @@ jobs:
     if: inputs.postCompileScript != ''
     runs-on: ${{ inputs.postCompileRunnerOs }}
     steps:
-    - uses: ./actions/endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
       with:
         azureCredentials: ${{ secrets.postCompilePhaseAzureCredentials }}
         additionalEnvVars: ${{ inputs.postCompilePhaseEnv}}
@@ -418,7 +418,7 @@ jobs:
       contents: write
       packages: write
     steps:
-    - uses: ./actions/endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
       with:
         azureCredentials: ${{ secrets.publishPhaseAzureCredentials }}
         additionalEnvVars: ${{ inputs.publishPhaseEnv}}

--- a/.github/workflows/scripted-build-matrix-pipeline.yml
+++ b/.github/workflows/scripted-build-matrix-pipeline.yml
@@ -169,37 +169,12 @@ jobs:
       preReleaseTag: ${{ steps.run_compile.outputs.preReleaseTag }}
 
     steps:
-    - name: Enable long paths
-      run: git config --global core.longpaths true
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: ./actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
       with:
-        fetch-depth: 0
-        submodules: true
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
-      with: 
-        environmentVariablesYamlBase64: ${{ inputs.compilePhaseEnv}}
-        secretsYamlBase64: ${{ secrets.compilePhaseSecrets}}
+        azureCredentials: ${{ secrets.compilePhaseAzureCredentials }}
+        additionalEnvVars: ${{ inputs.compilePhaseEnv}}
+        additionalSecrets: ${{ secrets.compilePhaseSecrets}}
         secretsEncryptionKey: ${{ secrets.secretsEncryptionKey }}
-    - name: Debug Variables
-      if: env.ACTIONS_RUNNER_DEBUG == 'true'
-      run: |
-        gci env:/ | fl | out-string | Write-Host
-      shell: pwsh
-    - name: Check if compilePhaseAzureCredentials secret is set
-      id: compilePhaseAzureCredentials_secret_check
-      shell: bash
-      run: |
-        if [ "${{ secrets.compilePhaseAzureCredentials }}" != '' ]; then
-          echo "available=true" >> $GITHUB_OUTPUT;
-        else
-          echo "available=false" >> $GITHUB_OUTPUT;
-        fi
-    - name: Azure CLI login
-      if: ${{ steps.compilePhaseAzureCredentials_secret_check.outputs.available == 'true' }}
-      uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43    # v3.0.0
-      with:
-        creds: ${{ secrets.compilePhaseAzureCredentials }}
-        enable-AzPSSession: true
     - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@main
       id: run_compile
       with:
@@ -241,36 +216,12 @@ jobs:
       matrix: ${{ fromJson(inputs.testPhaseMatrixJson) }}
     runs-on: ${{ matrix.os }}
     steps:
-    - name: Enable long paths
-      run: git config --global core.longpaths true
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+    - uses: ./actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
       with:
-        fetch-depth: 0
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
-      with: 
-        environmentVariablesYamlBase64: ${{ inputs.testPhaseEnv}}
-        secretsYamlBase64: ${{ secrets.testPhaseSecrets}}
+        azureCredentials: ${{ secrets.testPhaseAzureCredentials }}
+        additionalEnvVars: ${{ inputs.testPhaseEnv}}
+        additionalSecrets: ${{ secrets.testPhaseSecrets}}
         secretsEncryptionKey: ${{ secrets.secretsEncryptionKey }}
-    - name: Debug Variables
-      if: env.ACTIONS_RUNNER_DEBUG == 'true'
-      run: |
-        gci env:/ | fl | out-string | Write-Host
-      shell: pwsh
-    - name: Check if testPhaseAzureCredentials secret is set
-      id: testPhaseAzureCredentials_secret_check
-      shell: bash
-      run: |
-        if [ "${{ secrets.testPhaseAzureCredentials }}" != '' ]; then
-          echo "available=true" >> $GITHUB_OUTPUT;
-        else
-          echo "available=false" >> $GITHUB_OUTPUT;
-        fi
-    - name: Azure CLI login
-      if: ${{ steps.testPhaseAzureCredentials_secret_check.outputs.available == 'true' }}
-      uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43    # v3.0.0
-      with:
-        creds: ${{ secrets.testPhaseAzureCredentials }}
-        enable-AzPSSession: true
     - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@main
       with:
         displayName: Run Tests
@@ -365,36 +316,12 @@ jobs:
     name: Package
     runs-on: ${{ inputs.packagePhaseRunnerOs }}
     steps:
-    - name: Enable long paths
-      run: git config --global core.longpaths true
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+    - uses: ./actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
       with:
-        fetch-depth: 0
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
-      with: 
-        environmentVariablesYamlBase64: ${{ inputs.packagePhaseEnv}}
-        secretsYamlBase64: ${{ secrets.packagePhaseSecrets}}
+        azureCredentials: ${{ secrets.packagePhaseAzureCredentials }}
+        additionalEnvVars: ${{ inputs.packagePhaseEnv}}
+        additionalSecrets: ${{ secrets.packagePhaseSecrets}}
         secretsEncryptionKey: ${{ secrets.secretsEncryptionKey }}
-    - name: Debug Variables
-      if: env.ACTIONS_RUNNER_DEBUG == 'true'
-      run: |
-        gci env:/ | fl | out-string | Write-Host
-      shell: pwsh   
-    - name: Check if packagePhaseAzureCredentials secret is set
-      id: packagePhaseAzureCredentials_secret_check
-      shell: bash
-      run: |
-        if [ "${{ secrets.packagePhaseAzureCredentials }}" != '' ]; then
-          echo "available=true" >> $GITHUB_OUTPUT;
-        else
-          echo "available=false" >> $GITHUB_OUTPUT;
-        fi
-    - name: Azure CLI login
-      if: ${{ steps.packagePhaseAzureCredentials_secret_check.outputs.available == 'true' }}
-      uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43    # v3.0.0
-      with:
-        creds: ${{ secrets.packagePhaseAzureCredentials }}
-        enable-AzPSSession: true     
     - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@main
       with:
         displayName: Build Packages
@@ -415,23 +342,18 @@ jobs:
           _packages
           ${{ inputs.additionalCachePaths }}
 
-  post-compile:
+  postCompile:
     needs:
     - compile
     name: Post-Compile
     if: inputs.postCompileScript != ''
     runs-on: ${{ inputs.postCompileRunnerOs }}
     steps:
-    - name: Enable long paths
-      run: git config --global core.longpaths true
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: ./actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
       with:
-        fetch-depth: 0
-        submodules: true
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
-      with:
-        environmentVariablesYamlBase64: ${{ inputs.postCompilePhaseEnv }}
-        secretsYamlBase64: ${{ secrets.postCompilePhaseSecrets }}
+        azureCredentials: ${{ secrets.postCompilePhaseAzureCredentials }}
+        additionalEnvVars: ${{ inputs.postCompilePhaseEnv}}
+        additionalSecrets: ${{ secrets.postCompilePhaseSecrets }}
         secretsEncryptionKey: ${{ secrets.secretsEncryptionKey }}
     - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7   # v5.2.0
       name: Install .NET Core SDK ${{ inputs.netSdkVersion }}
@@ -476,7 +398,7 @@ jobs:
     - compile
     - test
     - package
-    - post-compile
+    - postCompile
     name: Publish
     if: inputs.forcePublish || startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
@@ -484,36 +406,12 @@ jobs:
       contents: write
       packages: write
     steps:
-    - name: Enable long paths
-      run: git config --global core.longpaths true
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   #v6.0.2
+    - uses: ./actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
       with:
-        fetch-depth: 0
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
-      with: 
-        environmentVariablesYamlBase64: ${{ inputs.publishPhaseEnv}}
-        secretsYamlBase64: ${{ secrets.publishPhaseSecrets}}
-        secretsEncryptionKey: ${{ secrets.secretsEncryptionKey }}
-    - name: Debug Variables
-      if: env.ACTIONS_RUNNER_DEBUG == 'true'
-      run: |
-        gci env:/ | fl | out-string | Write-Host
-      shell: pwsh    
-    - name: Check if publishPhaseAzureCredentials secret is set
-      id: publishPhaseAzureCredentials_secret_check
-      shell: bash
-      run: |
-        if [ "${{ secrets.publishPhaseAzureCredentials }}" != '' ]; then
-          echo "available=true" >> $GITHUB_OUTPUT;
-        else
-          echo "available=false" >> $GITHUB_OUTPUT;
-        fi
-    - name: Azure CLI login
-      if: ${{ steps.publishPhaseAzureCredentials_secret_check.outputs.available == 'true' }}
-      uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43    # v3.0.0
-      with:
-        creds: ${{ secrets.publishPhaseAzureCredentials }}
-        enable-AzPSSession: true    
+        azureCredentials: ${{ secrets.publishPhaseAzureCredentials }}
+        additionalEnvVars: ${{ inputs.publishPhaseEnv}}
+        additionalSecrets: ${{ secrets.publishPhaseSecrets}}
+        secretsEncryptionKey: ${{ secrets.secretsEncryptionKey }}  
     - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@main
       with:
         displayName: Publish Packages

--- a/.github/workflows/scripted-build-matrix-pipeline.yml
+++ b/.github/workflows/scripted-build-matrix-pipeline.yml
@@ -101,6 +101,30 @@ on:
         required: false
         default: windows-latest
         type: string
+      postCompileScript:
+        description: Optional PowerShell script to run in a parallel job after compile completes (alongside test and package). When set, a 'post-compile' job is added that restores the compile cache and runs this script.
+        required: false
+        default: ''
+        type: string
+      postCompileRunnerOs:
+        description: The operating system to run the optional 'post-compile' job on.
+        required: false
+        default: ubuntu-latest
+        type: string
+      postCompilePhaseEnv:
+        description: A JSON object representing the environment variables required when running the optional 'post-compile' job.
+        required: false
+        type: string
+      postCompileArtifactName:
+        description: If set, during the post-compile phase, uploads a GitHub artifact with the provided name (path must be specified in `postCompileArtifactPath`).
+        required: false
+        default: ''
+        type: string
+      postCompileArtifactPath:
+        description: If set, during the post-compile phase, uploads a GitHub artifact with the provided path (name must be specified in `postCompileArtifactName`). The path can be a file, directory or wildcard pattern; multiple paths can be specified using newline delimiter.
+        required: false
+        default: ''
+        type: string
 
     secrets:
       compilePhaseAzureCredentials:
@@ -122,6 +146,9 @@ on:
         required: false
       publishPhaseSecrets:
         description: A YAML string representing a dictionary of secrets required when running the 'publish' stage of this workflow.
+        required: false
+      postCompilePhaseSecrets:
+        description: A YAML string representing a dictionary of secrets required when running the optional 'post-compile' job.
         required: false
       secretsEncryptionKey:
         description: A string representing the shared secret used to encrypt the secrets YAML object.
@@ -388,11 +415,68 @@ jobs:
           _packages
           ${{ inputs.additionalCachePaths }}
 
+  post-compile:
+    needs:
+    - compile
+    name: Post-Compile
+    if: inputs.postCompileScript != ''
+    runs-on: ${{ inputs.postCompileRunnerOs }}
+    steps:
+    - name: Enable long paths
+      run: git config --global core.longpaths true
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        fetch-depth: 0
+        submodules: true
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
+      with:
+        environmentVariablesYamlBase64: ${{ inputs.postCompilePhaseEnv }}
+        secretsYamlBase64: ${{ secrets.postCompilePhaseSecrets }}
+        secretsEncryptionKey: ${{ secrets.secretsEncryptionKey }}
+    - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7   # v5.2.0
+      name: Install .NET Core SDK ${{ inputs.netSdkVersion }}
+      with:
+        dotnet-version: '${{ inputs.netSdkVersion }}'
+    - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7   # v5.2.0
+      if: inputs.additionalNetSdkVersion != ''
+      name: Install .NET Core SDK ${{ inputs.additionalNetSdkVersion }}
+      with:
+        dotnet-version: '${{ inputs.additionalNetSdkVersion }}'
+    - name: Restore compile cache
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae    # v5.0.5
+      id: cache_restore
+      with:
+        path: |
+          .nuget-packages
+          Solutions
+          solutions
+          ${{ inputs.additionalCachePaths }}
+        key: build-state-${{ github.run_id }}-compile
+        enableCrossOsArchive: ${{ inputs.enableCrossOsCaching }}
+    - name: Ensure compile cache restored
+      if: steps.cache_restore.outputs.cache-hit == 'false'
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3   # v9.0.0
+      with:
+        script: |
+          core.setFailed('Aborting post-compile: GHA cache restore failure of required compile state')
+    - name: Run post-compile script
+      run: pwsh -File ${{ inputs.postCompileScript }}
+      env:
+        NUGET_PACKAGES: ${{ github.workspace }}/.nuget-packages
+    - name: Upload artifact
+      if: inputs.postCompileArtifactName != '' && inputs.postCompileArtifactPath != ''
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a    # v7.0.1
+      with:
+        name: ${{ inputs.postCompileArtifactName }}
+        path: ${{ inputs.postCompileArtifactPath }}
+        include-hidden-files: true
+
   publish:
     needs:
     - compile
     - test
     - package
+    - post-compile
     name: Publish
     if: inputs.forcePublish || startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest

--- a/.github/workflows/scripted-build-matrix-pipeline.yml
+++ b/.github/workflows/scripted-build-matrix-pipeline.yml
@@ -189,7 +189,7 @@ jobs:
       preReleaseTag: ${{ steps.run_compile.outputs.preReleaseTag }}
 
     steps:
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@main
       with:
         azureCredentials: ${{ secrets.compilePhaseAzureCredentials }}
         additionalEnvVars: ${{ inputs.compilePhaseEnv}}
@@ -236,7 +236,7 @@ jobs:
       matrix: ${{ fromJson(inputs.testPhaseMatrixJson) }}
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@main
       with:
         azureCredentials: ${{ secrets.testPhaseAzureCredentials }}
         additionalEnvVars: ${{ inputs.testPhaseEnv}}
@@ -340,7 +340,7 @@ jobs:
     name: Package
     runs-on: ${{ inputs.packagePhaseRunnerOs }}
     steps:
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@main
       with:
         azureCredentials: ${{ secrets.packagePhaseAzureCredentials }}
         additionalEnvVars: ${{ inputs.packagePhaseEnv}}
@@ -373,7 +373,7 @@ jobs:
     if: inputs.postCompilePhaseTasks != ''
     runs-on: ${{ inputs.postCompileRunnerOs }}
     steps:
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@main
       with:
         azureCredentials: ${{ secrets.postCompilePhaseAzureCredentials }}
         additionalEnvVars: ${{ inputs.postCompilePhaseEnv}}
@@ -423,7 +423,7 @@ jobs:
       contents: write
       packages: write
     steps:
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@main
       with:
         azureCredentials: ${{ secrets.publishPhaseAzureCredentials }}
         additionalEnvVars: ${{ inputs.publishPhaseEnv}}

--- a/.github/workflows/scripted-build-pipeline.yml
+++ b/.github/workflows/scripted-build-pipeline.yml
@@ -96,6 +96,30 @@ on:
         required: false
         default: ubuntu-latest
         type: string
+      postCompileRunnerOs:
+        description: The operating system to run the optional 'post-compile' job on.
+        required: false
+        default: ubuntu-latest
+        type: string
+      postCompilePhaseEnv:
+        description: A JSON object representing the environment variables required when running the optional 'post-compile' job.
+        required: false
+        type: string
+      postCompilePhaseTasks:
+        description: The tasks that need to be run as part of the 'post-compile' stage, formatted as a comma-delimited string.
+        required: false
+        default: ''
+        type: string
+      postCompileArtifactName:
+        description: If set, during the post-compile phase, uploads a GitHub artifact with the provided name (path must be specified in `postCompileArtifactPath`).
+        required: false
+        default: ''
+        type: string
+      postCompileArtifactPath:
+        description: If set, during the post-compile phase, uploads a GitHub artifact with the provided path (name must be specified in `postCompileArtifactName`). The path can be a file, directory or wildcard pattern; multiple paths can be specified using newline delimiter.
+        required: false
+        default: ''
+        type: string        
 
     secrets:
       compilePhaseAzureCredentials:
@@ -306,6 +330,49 @@ jobs:
         outputCachePaths: |
           _packages
           ${{ inputs.additionalCachePaths }}
+
+  postCompile:
+    needs:
+    - compile
+    name: Post-Compile
+    if: inputs.postCompilePhaseTasks != ''
+    runs-on: ${{ inputs.postCompileRunnerOs }}
+    steps:
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
+      with:
+        azureCredentials: ${{ secrets.postCompilePhaseAzureCredentials }}
+        additionalEnvVars: ${{ inputs.postCompilePhaseEnv}}
+        additionalSecrets: ${{ secrets.postCompilePhaseSecrets }}
+        secretsEncryptionKey: ${{ secrets.secretsEncryptionKey }}
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@main
+      id: run_post_compile
+      with:
+        displayName: Post-Compile
+        buildScriptPath: ${{ inputs.buildScriptPath }}
+        netSdkVersion: ${{ inputs.netSdkVersion }}
+        additionalNetSdkVersion: ${{ inputs.additionalNetSdkVersion }}
+        pythonVersion: ${{ inputs.pythonVersion }}
+        tasks: ${{ inputs.postCompilePhaseTasks }}
+        configuration: ${{ inputs.configuration }}
+        inputCacheKeySuffix: compile
+        inputCachePaths: |
+          .nuget-packages
+          Solutions
+          solutions
+          ${{ inputs.additionalCachePaths }}
+        outputCacheKeySuffix: postcompile
+        outputCachePaths: |
+          .nuget-packages
+          Solutions
+          solutions
+          ${{ inputs.additionalCachePaths }}
+    - name: Upload artifact
+      if: inputs.postCompileArtifactName != '' && inputs.postCompileArtifactPath != ''
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a    # v7.0.1
+      with:
+        name: ${{ inputs.postCompileArtifactName }}
+        path: ${{ inputs.postCompileArtifactPath }}
+        include-hidden-files: true
 
   publish:
     needs:

--- a/.github/workflows/scripted-build-pipeline.yml
+++ b/.github/workflows/scripted-build-pipeline.yml
@@ -117,7 +117,7 @@ jobs:
       preReleaseTag: ${{ steps.run_compile.outputs.preReleaseTag }}
 
     steps:
-    - uses: ./actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
+    - uses: ./actions/endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
       with:
         azureCredentials: ${{ secrets.compilePhaseAzureCredentials }}
         additionalEnvVars: ${{ inputs.compilePhaseEnv}}
@@ -160,7 +160,7 @@ jobs:
     name: Test
     runs-on: ${{ inputs.runsOn }}
     steps:
-    - uses: ./actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
+    - uses: ./actions/endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
       with:
         azureCredentials: ${{ secrets.testPhaseAzureCredentials }}
         additionalEnvVars: ${{ inputs.testPhaseEnv}}
@@ -262,7 +262,7 @@ jobs:
     name: Package
     runs-on: ${{ inputs.runsOn }}
     steps:
-    - uses: ./actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
+    - uses: ./actions/endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
       with:
         azureCredentials: ${{ secrets.packagePhaseAzureCredentials }}
         additionalEnvVars: ${{ inputs.packagePhaseEnv}}
@@ -299,7 +299,7 @@ jobs:
       contents: write
       packages: write
     steps:
-    - uses: ./actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
+    - uses: ./actions/endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
       with:
         azureCredentials: ${{ secrets.publishPhaseAzureCredentials }}
         additionalEnvVars: ${{ inputs.publishPhaseEnv}}

--- a/.github/workflows/scripted-build-pipeline.yml
+++ b/.github/workflows/scripted-build-pipeline.yml
@@ -117,7 +117,7 @@ jobs:
       preReleaseTag: ${{ steps.run_compile.outputs.preReleaseTag }}
 
     steps:
-    - uses: ./actions/endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
       with:
         azureCredentials: ${{ secrets.compilePhaseAzureCredentials }}
         additionalEnvVars: ${{ inputs.compilePhaseEnv}}
@@ -160,7 +160,7 @@ jobs:
     name: Test
     runs-on: ${{ inputs.runsOn }}
     steps:
-    - uses: ./actions/endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
       with:
         azureCredentials: ${{ secrets.testPhaseAzureCredentials }}
         additionalEnvVars: ${{ inputs.testPhaseEnv}}
@@ -262,7 +262,7 @@ jobs:
     name: Package
     runs-on: ${{ inputs.runsOn }}
     steps:
-    - uses: ./actions/endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
       with:
         azureCredentials: ${{ secrets.packagePhaseAzureCredentials }}
         additionalEnvVars: ${{ inputs.packagePhaseEnv}}
@@ -299,7 +299,7 @@ jobs:
       contents: write
       packages: write
     steps:
-    - uses: ./actions/endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
       with:
         azureCredentials: ${{ secrets.publishPhaseAzureCredentials }}
         additionalEnvVars: ${{ inputs.publishPhaseEnv}}

--- a/.github/workflows/scripted-build-pipeline.yml
+++ b/.github/workflows/scripted-build-pipeline.yml
@@ -117,37 +117,12 @@ jobs:
       preReleaseTag: ${{ steps.run_compile.outputs.preReleaseTag }}
 
     steps:
-    - name: Enable long paths
-      run: git config --global core.longpaths true
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+    - uses: ./actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
       with:
-        fetch-depth: 0
-        submodules: true
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
-      with: 
-        environmentVariablesYamlBase64: ${{ inputs.compilePhaseEnv}}
-        secretsYamlBase64: ${{ secrets.compilePhaseSecrets}}
+        azureCredentials: ${{ secrets.compilePhaseAzureCredentials }}
+        additionalEnvVars: ${{ inputs.compilePhaseEnv}}
+        additionalSecrets: ${{ secrets.compilePhaseSecrets}}
         secretsEncryptionKey: ${{ secrets.secretsEncryptionKey }}
-    - name: Debug Variables
-      if: env.ACTIONS_RUNNER_DEBUG == 'true'
-      run: |
-        gci env:/ | fl | out-string | Write-Host
-      shell: pwsh
-    - name: Check if compilePhaseAzureCredentials secret is set
-      id: compilePhaseAzureCredentials_secret_check
-      shell: bash
-      run: |
-        if [ "${{ secrets.compilePhaseAzureCredentials }}" != '' ]; then
-          echo "available=true" >> $GITHUB_OUTPUT;
-        else
-          echo "available=false" >> $GITHUB_OUTPUT;
-        fi
-    - name: Azure CLI login
-      if: ${{ steps.compilePhaseAzureCredentials_secret_check.outputs.available == 'true' }}
-      uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43    # v3.0.0
-      with:
-        creds: ${{ secrets.compilePhaseAzureCredentials }}
-        enable-AzPSSession: true
     - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@main
       id: run_compile
       with:
@@ -185,36 +160,12 @@ jobs:
     name: Test
     runs-on: ${{ inputs.runsOn }}
     steps:
-    - name: Enable long paths
-      run: git config --global core.longpaths true
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: ./actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
       with:
-        fetch-depth: 0
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
-      with: 
-        environmentVariablesYamlBase64: ${{ inputs.testPhaseEnv}}
-        secretsYamlBase64: ${{ secrets.testPhaseSecrets}}
+        azureCredentials: ${{ secrets.testPhaseAzureCredentials }}
+        additionalEnvVars: ${{ inputs.testPhaseEnv}}
+        additionalSecrets: ${{ secrets.testPhaseSecrets}}
         secretsEncryptionKey: ${{ secrets.secretsEncryptionKey }}
-    - name: Debug Variables
-      if: env.ACTIONS_RUNNER_DEBUG == 'true'
-      run: |
-        gci env:/ | fl | out-string | Write-Host
-      shell: pwsh
-    - name: Check if testPhaseAzureCredentials secret is set
-      id: testPhaseAzureCredentials_secret_check
-      shell: bash
-      run: |
-        if [ "${{ secrets.testPhaseAzureCredentials }}" != '' ]; then
-          echo "available=true" >> $GITHUB_OUTPUT;
-        else
-          echo "available=false" >> $GITHUB_OUTPUT;
-        fi
-    - name: Azure CLI login
-      if: ${{ steps.testPhaseAzureCredentials_secret_check.outputs.available == 'true' }}
-      uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43    # v3.0.0
-      with:
-        creds: ${{ secrets.testPhaseAzureCredentials }}
-        enable-AzPSSession: true
     - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@main
       with:
         displayName: Run Tests
@@ -307,36 +258,12 @@ jobs:
     name: Package
     runs-on: ${{ inputs.runsOn }}
     steps:
-    - name: Enable long paths
-      run: git config --global core.longpaths true
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+    - uses: ./actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
       with:
-        fetch-depth: 0
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
-      with: 
-        environmentVariablesYamlBase64: ${{ inputs.packagePhaseEnv}}
-        secretsYamlBase64: ${{ secrets.packagePhaseSecrets}}
-        secretsEncryptionKey: ${{ secrets.secretsEncryptionKey }}
-    - name: Debug Variables
-      if: env.ACTIONS_RUNNER_DEBUG == 'true'
-      run: |
-        gci env:/ | fl | out-string | Write-Host
-      shell: pwsh   
-    - name: Check if packagePhaseAzureCredentials secret is set
-      id: packagePhaseAzureCredentials_secret_check
-      shell: bash
-      run: |
-        if [ "${{ secrets.packagePhaseAzureCredentials }}" != '' ]; then
-          echo "available=true" >> $GITHUB_OUTPUT;
-        else
-          echo "available=false" >> $GITHUB_OUTPUT;
-        fi
-    - name: Azure CLI login
-      if: ${{ steps.packagePhaseAzureCredentials_secret_check.outputs.available == 'true' }}
-      uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43    # v3.0.0
-      with:
-        creds: ${{ secrets.packagePhaseAzureCredentials }}
-        enable-AzPSSession: true     
+        azureCredentials: ${{ secrets.packagePhaseAzureCredentials }}
+        additionalEnvVars: ${{ inputs.packagePhaseEnv}}
+        additionalSecrets: ${{ secrets.packagePhaseSecrets}}
+        secretsEncryptionKey: ${{ secrets.secretsEncryptionKey }} 
     - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@main
       with:
         displayName: Build Packages
@@ -368,36 +295,12 @@ jobs:
       contents: write
       packages: write
     steps:
-    - name: Enable long paths
-      run: git config --global core.longpaths true
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   #v6.0.2
+    - uses: ./actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
       with:
-        fetch-depth: 0
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
-      with: 
-        environmentVariablesYamlBase64: ${{ inputs.publishPhaseEnv}}
-        secretsYamlBase64: ${{ secrets.publishPhaseSecrets}}
-        secretsEncryptionKey: ${{ secrets.secretsEncryptionKey }}
-    - name: Debug Variables
-      if: env.ACTIONS_RUNNER_DEBUG == 'true'
-      run: |
-        gci env:/ | fl | out-string | Write-Host
-      shell: pwsh    
-    - name: Check if publishPhaseAzureCredentials secret is set
-      id: publishPhaseAzureCredentials_secret_check
-      shell: bash
-      run: |
-        if [ "${{ secrets.publishPhaseAzureCredentials }}" != '' ]; then
-          echo "available=true" >> $GITHUB_OUTPUT;
-        else
-          echo "available=false" >> $GITHUB_OUTPUT;
-        fi
-    - name: Azure CLI login
-      if: ${{ steps.publishPhaseAzureCredentials_secret_check.outputs.available == 'true' }}
-      uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43    # v3.0.0
-      with:
-        creds: ${{ secrets.publishPhaseAzureCredentials }}
-        enable-AzPSSession: true    
+        azureCredentials: ${{ secrets.publishPhaseAzureCredentials }}
+        additionalEnvVars: ${{ inputs.publishPhaseEnv}}
+        additionalSecrets: ${{ secrets.publishPhaseSecrets}}
+        secretsEncryptionKey: ${{ secrets.secretsEncryptionKey }} 
     - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@main
       with:
         displayName: Publish Packages

--- a/.github/workflows/scripted-build-pipeline.yml
+++ b/.github/workflows/scripted-build-pipeline.yml
@@ -117,7 +117,7 @@ jobs:
       preReleaseTag: ${{ steps.run_compile.outputs.preReleaseTag }}
 
     steps:
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@main
       with:
         azureCredentials: ${{ secrets.compilePhaseAzureCredentials }}
         additionalEnvVars: ${{ inputs.compilePhaseEnv}}
@@ -160,7 +160,7 @@ jobs:
     name: Test
     runs-on: ${{ inputs.runsOn }}
     steps:
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@main
       with:
         azureCredentials: ${{ secrets.testPhaseAzureCredentials }}
         additionalEnvVars: ${{ inputs.testPhaseEnv}}
@@ -262,7 +262,7 @@ jobs:
     name: Package
     runs-on: ${{ inputs.runsOn }}
     steps:
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@main
       with:
         azureCredentials: ${{ secrets.packagePhaseAzureCredentials }}
         additionalEnvVars: ${{ inputs.packagePhaseEnv}}
@@ -299,7 +299,7 @@ jobs:
       contents: write
       packages: write
     steps:
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@main
       with:
         azureCredentials: ${{ secrets.publishPhaseAzureCredentials }}
         additionalEnvVars: ${{ inputs.publishPhaseEnv}}

--- a/.github/workflows/scripted-build-pipeline.yml
+++ b/.github/workflows/scripted-build-pipeline.yml
@@ -28,10 +28,20 @@ on:
         description: A JSON object representing the environment variables required when running the 'compile' stage of this workflow.
         required: false
         type: string
+      compilePhaseTasks:
+        description: The tasks that need to be run as part of the 'compile' stage, formatted as a comma-delimited string (e.g. 'Build' or 'Build,Analysis').
+        required: false
+        default: 'Build,Analysis'
+        type: string        
       testPhaseEnv:
         description: A JSON object representing the environment variables required when running the 'test' stage of this workflow.
         required: false
         type: string
+      testPhaseTasks:
+        description: The tasks that need to be run as part of the 'test' stage, formatted as a comma-delimited string (e.g. 'Test' or 'Test,TestReport').
+        required: false
+        default: 'Test'
+        type: string        
       testArtifactName:
         description: If set, during the test phase, uploads a GitHub artifact with the provided name (path must be specified in `artifactPath`)
         required: false
@@ -44,10 +54,20 @@ on:
         description: A JSON object representing the environment variables required when running the 'package' stage of this workflow.
         required: false
         type: string
+      packagePhaseTasks:
+        description: The tasks that need to be run as part of the 'package' stage, formatted as a comma-delimited string.
+        required: false
+        default: 'Package'
+        type: string        
       publishPhaseEnv:
         description: A JSON object representing the environment variables required when running the 'publish' stage of this workflow.
         required: false
         type: string
+      publishPhaseTasks:
+        description: The tasks that need to be run as part of the 'publish' stage, formatted as a comma-delimited string.
+        required: false
+        default: 'Publish'
+        type: string        
       publishArtifactName:
         description: If set, during the publish phase, uploads a GitHub artifact with the provided name (path must be specified in `artifactPath`)
         required: false
@@ -131,7 +151,7 @@ jobs:
         netSdkVersion: ${{ inputs.netSdkVersion }}
         additionalNetSdkVersion: ${{ inputs.additionalNetSdkVersion }}
         pythonVersion: ${{ inputs.pythonVersion }}
-        tasks: 'Build,Analysis'
+        tasks: ${{ inputs.compilePhaseTasks }}
         configuration: ${{ inputs.configuration }}
         outputCacheKeySuffix: compile
         outputCachePaths: |
@@ -172,7 +192,7 @@ jobs:
         buildScriptPath: ${{ inputs.buildScriptPath }}
         netSdkVersion: ${{ inputs.netSdkVersion }}
         additionalNetSdkVersion: ${{ inputs.additionalNetSdkVersion }}
-        tasks: 'Test'
+        tasks: ${{ inputs.testPhaseTasks }}
         configuration: ${{ inputs.configuration }}
         inputCacheKeySuffix: compile
         inputCachePaths: |
@@ -274,7 +294,7 @@ jobs:
         buildScriptPath: ${{ inputs.buildScriptPath }}
         netSdkVersion: ${{ inputs.netSdkVersion }}
         additionalNetSdkVersion: ${{ inputs.additionalNetSdkVersion }}
-        tasks: 'Package'
+        tasks: ${{ inputs.packagePhaseTasks }}
         configuration: ${{ inputs.configuration }}
         inputCacheKeySuffix: compile
         inputCachePaths: |
@@ -311,7 +331,7 @@ jobs:
         buildScriptPath: ${{ inputs.buildScriptPath }}
         netSdkVersion: ${{ inputs.netSdkVersion }}
         additionalNetSdkVersion: ${{ inputs.additionalNetSdkVersion }}
-        tasks: 'Publish'
+        tasks: ${{ inputs.publishPhaseTasks }}
         inputCacheKeySuffix: package
         inputCachePaths: |
           _packages

--- a/.github/workflows/scripted-build-pipeline.yml
+++ b/.github/workflows/scripted-build-pipeline.yml
@@ -241,16 +241,20 @@ jobs:
       uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040   # v2.23.0
       if: always() && steps.check_os.outputs.RUNNEROS == 'linux'
       with:
-        nunit_files: "*TestResults.xml"    # produced by Pester
-        trx_files: "**/test-results_*.trx" # produced by dotnet test
-        junit_files: "**/*-test-results.xml" # produced by PyTest & Behave
+        # Look for test results produced by Pester, VSTest/MTP & PyTest/Behave
+        files: |
+          TestResults.xml
+          **/test-results*.trx
+          **/*-test-results.xml
     - name: Publish Test Results (Windows)
       uses: EnricoMi/publish-unit-test-result-action/windows@c950f6fb443cb5af20a377fd0dfaa78838901040   # v2.23.0
       if: always() && steps.check_os.outputs.RUNNEROS == 'windows'
       with:
-        nunit_files: "*TestResults.xml"    # produced by Pester
-        trx_files: "**/test-results_*.trx" # produced by dotnet test
-        junit_files: "**/*-test-results.xml" # produced by PyTest & Behave
+        # Look for test results produced by Pester, VSTest/MTP & PyTest/Behave
+        files: |
+          TestResults.xml
+          **/test-results*.trx
+          **/*-test-results.xml
 
   package:
     needs:

--- a/.github/workflows/scripted-build-pipeline.yml
+++ b/.github/workflows/scripted-build-pipeline.yml
@@ -161,7 +161,7 @@ jobs:
       preReleaseTag: ${{ steps.run_compile.outputs.preReleaseTag }}
 
     steps:
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@main
       with:
         azureCredentials: ${{ secrets.compilePhaseAzureCredentials }}
         additionalEnvVars: ${{ inputs.compilePhaseEnv}}
@@ -204,7 +204,7 @@ jobs:
     name: Test
     runs-on: ${{ inputs.runsOn }}
     steps:
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@main
       with:
         azureCredentials: ${{ secrets.testPhaseAzureCredentials }}
         additionalEnvVars: ${{ inputs.testPhaseEnv}}
@@ -306,7 +306,7 @@ jobs:
     name: Package
     runs-on: ${{ inputs.runsOn }}
     steps:
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@main
       with:
         azureCredentials: ${{ secrets.packagePhaseAzureCredentials }}
         additionalEnvVars: ${{ inputs.packagePhaseEnv}}
@@ -386,7 +386,7 @@ jobs:
       contents: write
       packages: write
     steps:
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@main
       with:
         azureCredentials: ${{ secrets.publishPhaseAzureCredentials }}
         additionalEnvVars: ${{ inputs.publishPhaseEnv}}

--- a/.github/workflows/scripted-build-pipeline.yml
+++ b/.github/workflows/scripted-build-pipeline.yml
@@ -137,7 +137,7 @@ jobs:
       preReleaseTag: ${{ steps.run_compile.outputs.preReleaseTag }}
 
     steps:
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@main
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
       with:
         azureCredentials: ${{ secrets.compilePhaseAzureCredentials }}
         additionalEnvVars: ${{ inputs.compilePhaseEnv}}
@@ -180,7 +180,7 @@ jobs:
     name: Test
     runs-on: ${{ inputs.runsOn }}
     steps:
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@main
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
       with:
         azureCredentials: ${{ secrets.testPhaseAzureCredentials }}
         additionalEnvVars: ${{ inputs.testPhaseEnv}}
@@ -282,7 +282,7 @@ jobs:
     name: Package
     runs-on: ${{ inputs.runsOn }}
     steps:
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@main
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
       with:
         azureCredentials: ${{ secrets.packagePhaseAzureCredentials }}
         additionalEnvVars: ${{ inputs.packagePhaseEnv}}
@@ -319,7 +319,7 @@ jobs:
       contents: write
       packages: write
     steps:
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@main
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
       with:
         azureCredentials: ${{ secrets.publishPhaseAzureCredentials }}
         additionalEnvVars: ${{ inputs.publishPhaseEnv}}

--- a/README.md
+++ b/README.md
@@ -50,7 +50,19 @@ graph LR
     postcompile-->publish
 ```
 
-The Post-Compile phase is optional and only runs when the `postCompileScript` input is set. It restores the compile cache and runs a custom PowerShell script in parallel with the Test and Package phases. This is useful for heavy post-compile work such as documentation website builds that don't need to block tests.
+The Post-Compile phase is optional and only runs when the `postCompilePhaseTasks` input is set. It runs a standard scripted build using the default task of `postCompile` (overridable via the `postCompilePhaseTasks` intput) and runs in parallel with the Test and Package phases. This is useful for heavy post-compile work such as documentation website builds that don't need to block tests.
+
+#### Customising Build Tasks
+
+These multi-job workflows support customising which InvokeBuild tasks are run for each stage via inputs that accept one or more comma-delimited task names, as shown in the table below:
+
+| Stage       | Input Name              | Defaults       |
+| ----------- | ----------------------- | -------------- |
+| Compile     | `compilePhaseTasks`     | Build,Analysis |
+| Test        | `testPhaseTasks`        | Test           |
+| Package     | `packagePhaseTasks`     | Package        |
+| PostCompile | `postCompilePhaseTasks` | postCompile    |
+| Publish     | `publishPhaseTasks`     | Publish        |
 
 
 ### Single-Job Workflow
@@ -70,6 +82,10 @@ graph LR
     package-->publish["Publish Packages"]
     publish-->pubtests["Publish Test Results"] 
 ```
+
+### Customising Build Tasks
+
+This single-job workflow option supports customising which InvokeBuild tasks are run via the `buildTasks` input that accepts one or more comma-delimited task named.
 
 
 ## Composite Actions
@@ -98,6 +114,12 @@ These composite actions are used to encapsulated specific functionality so it ca
 - `run-scripted-build` - encapsulates the steps for executing our [PowerShell-based build tooling](https://www.powershellgallery.com/packages/Endjin.RecommendedPractices.Build) - typically used via one of the above reusable workflows.
 - `set-env-vars-and-secrets` - the consuming side of the workaround for passing arbitrary environment variables and secrets. Unwraps the bundled environment variables and secrets so they are available to the running workflow.
 
+### Customising Build Tasks
+
+This composite action supports customising which InvokeBuild tasks are run via the `buildTasks` input that accepts one or more comma-delimited task named.
+
+
+
 ## Examples
 
 The following workflows serve as examples of how to consume the different reusable workflows and composite actions found in this repo:
@@ -106,5 +128,3 @@ The following workflows serve as examples of how to consume the different reusab
 - [ci-matrix.yml](.github/workflows/ci-matrix.yml) - used for validating changes to the `scripted-build-matrix-pipeline` reusable workflow
 - [ci-single-job.yml](.github/workflows/ci-single-job.yml) - used for validating changes to the `scripted-build-single-job-pipeline` reusable workflow
 - [ci-composite-action](.github/workflows/ci-composite-action.yml) - used for validating change to the `run-build-process` composite action
-
-

--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ The Post-Compile phase is optional and only runs when the `postCompilePhaseTasks
 
 These multi-job workflows support customising which InvokeBuild tasks are run for each stage via inputs that accept one or more comma-delimited task names, as shown in the table below:
 
-| Stage       | Input Name              | Defaults       |
-| ----------- | ----------------------- | -------------- |
-| Compile     | `compilePhaseTasks`     | Build,Analysis |
-| Test        | `testPhaseTasks`        | Test           |
-| Package     | `packagePhaseTasks`     | Package        |
-| PostCompile | `postCompilePhaseTasks` | postCompile    |
-| Publish     | `publishPhaseTasks`     | Publish        |
+| Stage       | Input Name              | Defaults                                               |
+| ----------- | ----------------------- | ------------------------------------------------------ |
+| Compile     | `compilePhaseTasks`     | Build,Analysis                                         |
+| Test        | `testPhaseTasks`        | Test                                                   |
+| Package     | `packagePhaseTasks`     | Package                                                |
+| PostCompile | `postCompilePhaseTasks` | '' (this phase will not run unless explicitly defined) |
+| Publish     | `publishPhaseTasks`     | Publish                                                |
 
 
 ### Single-Job Workflow

--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ The Post-Compile phase is optional and only runs when the `postCompilePhaseTasks
 
 These multi-job workflows support customising which InvokeBuild tasks are run for each stage via inputs that accept one or more comma-delimited task names, as shown in the table below:
 
-| Stage       | Input Name              | Defaults                                               |
-| ----------- | ----------------------- | ------------------------------------------------------ |
-| Compile     | `compilePhaseTasks`     | Build,Analysis                                         |
-| Test        | `testPhaseTasks`        | Test                                                   |
-| Package     | `packagePhaseTasks`     | Package                                                |
-| PostCompile | `postCompilePhaseTasks` | '' (this phase will not run unless explicitly defined) |
-| Publish     | `publishPhaseTasks`     | Publish                                                |
+| Stage       | Input Name              | Defaults                                                     |
+| ----------- | ----------------------- | ------------------------------------------------------------ |
+| Compile     | `compilePhaseTasks`     | Build,Analysis                                               |
+| Test        | `testPhaseTasks`        | Test                                                         |
+| Package     | `packagePhaseTasks`     | Package                                                      |
+| PostCompile | `postCompilePhaseTasks` | '' (this phase will not run unless a task is explicitly set) |
+| Publish     | `publishPhaseTasks`     | Publish                                                      |
 
 
 ### Single-Job Workflow

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Our standardised build process is divided into the following phases:
 - Test
 - Analyse
 - Package
+- Post-Compile *(optional, runs in parallel with Test and Package)*
 - Publish
 
 By default, the 'Publish' phase is only executed for tagged versions or when manually triggered with the 'Force Publish' option enabled.
@@ -43,9 +44,13 @@ graph LR
     test1-->pubtests["Publish Test Results"] 
     test2-->pubtests["Publish Test Results"] 
     analyse-->package["Build Packages"]
+    analyse-->postcompile["Post-Compile (optional)"]
     pubtests-->publish["Publish Packages"]
     package-->publish
+    postcompile-->publish
 ```
+
+The Post-Compile phase is optional and only runs when the `postCompileScript` input is set. It restores the compile cache and runs a custom PowerShell script in parallel with the Test and Package phases. This is useful for heavy post-compile work such as documentation website builds that don't need to block tests.
 
 
 ### Single-Job Workflow

--- a/actions/common-pre-scripted-build/action.yml
+++ b/actions/common-pre-scripted-build/action.yml
@@ -21,6 +21,7 @@ runs:
   steps:
   - name: Enable long paths
     run: git config --global core.longpaths true
+    shell: pwsh
   - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     with:
       fetch-depth: 0

--- a/actions/common-pre-scripted-build/action.yml
+++ b/actions/common-pre-scripted-build/action.yml
@@ -1,0 +1,52 @@
+name: common-pre-run-scripted-build
+description: Common steps typically required before running the 'run-scripted-build' composite action
+inputs:
+  azureCredentials:
+    description: 
+    required: false
+    default: ''
+  additionalEnvVars:
+    description: A JSON object representing the environment variables required when running the 'compile' stage of this workflow.
+    required: false
+    type: string
+  additionalSecrets:
+    description: A YAML string representing a dictionary of secrets required when running the 'compile' stage of this workflow.
+    required: false
+  secretsEncryptionKey:
+    description: A string representing the shared secret used to encrypt the secrets YAML object.
+    required: false
+
+runs:
+  using: "composite"  
+  steps:
+  - name: Enable long paths
+    run: git config --global core.longpaths true
+  - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    with:
+      fetch-depth: 0
+      submodules: true
+  - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
+    with: 
+      environmentVariablesYamlBase64: ${{ inputs.additionalEnvVars}}
+      secretsYamlBase64: ${{ inputs.additionalSecrets}}
+      secretsEncryptionKey: ${{ inputs.secretsEncryptionKey }}
+  - name: Debug Variables
+    if: env.ACTIONS_RUNNER_DEBUG == 'true'
+    run: |
+      gci env:/ | fl | out-string | Write-Host
+    shell: pwsh
+  - name: Check if azureCredentials secret is set
+    id: azureCredentials_secret_check
+    shell: bash
+    run: |
+      if [ "${{ inputs.azureCredentials }}" != '' ]; then
+        echo "available=true" >> $GITHUB_OUTPUT;
+      else
+        echo "available=false" >> $GITHUB_OUTPUT;
+      fi
+  - name: Azure CLI login
+    if: ${{ !inputs.azureCredentials != '' }}
+    uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43    # v3.0.0
+    with:
+      creds: ${{ inputs.azureCredentials }}
+      enable-AzPSSession: true

--- a/actions/common-pre-scripted-build/action.yml
+++ b/actions/common-pre-scripted-build/action.yml
@@ -46,7 +46,7 @@ runs:
         echo "available=false" >> $GITHUB_OUTPUT;
       fi
   - name: Azure CLI login
-    if: ${{ !inputs.azureCredentials != '' }}
+    if: ${{ inputs.azureCredentials != '' }}
     uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43    # v3.0.0
     with:
       creds: ${{ inputs.azureCredentials }}

--- a/actions/run-build-process/action.yml
+++ b/actions/run-build-process/action.yml
@@ -85,47 +85,12 @@ outputs:
 runs:
   using: "composite"  
   steps:
-    - name: Enable long paths
-      run: git config --global core.longpaths true
-      shell: bash
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+    - uses: ./actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
       with:
-        fetch-depth: 0
-        submodules: true
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/set-env-vars-and-secrets@main
-      with: 
-        environmentVariablesYamlBase64: ${{ inputs.buildEnv}}
-        secretsYamlBase64: ${{ inputs.buildSecrets}}
+        azureCredentials: ${{ inputs.buildAzureCredentials }}
+        additionalEnvVars: ${{ inputs.buildEnv }}
+        additionalSecrets: ${{ inputs.buildSecrets}}
         secretsEncryptionKey: ${{ inputs.secretsEncryptionKey }}
-    - name: Set defaults
-      id: set_defaults
-      run: |
-        echo "inputs: ${{ toJson(inputs) }}"
-        echo "ref: ${{ github.ref }}"
-        echo "CODE_COVERAGE_SUMMARY_DIR=${{ inputs.codeCoverageSummaryDir || '_codeCoverage' }}" >> $GITHUB_OUTPUT
-        echo "CODE_COVERAGE_SUMMARY_FILE=${{ inputs.codeCoverageSummaryFile || 'SummaryGithub.md' }}" >> $GITHUB_OUTPUT
-        echo "DEFAULT_BUILD_TASKS=${{ (inputs.forcePublish == 'true' || startsWith(github.ref, 'refs/tags/')) && 'FullBuildAndPublish' || 'FullBuild' }}" >> $GITHUB_OUTPUT
-      shell: bash
-    - name: Debug Variables
-      if: env.ACTIONS_RUNNER_DEBUG == 'true'
-      run: |
-        gci env:/ | fl | out-string | Write-Host
-      shell: pwsh
-    - name: Check if buildAzureCredentials secret is set
-      id: buildAzureCredentials_secret_check
-      shell: bash
-      run: |
-        if [ "${{ inputs.buildAzureCredentials }}" != '' ]; then
-          echo "available=true" >> $GITHUB_OUTPUT;
-        else
-          echo "available=false" >> $GITHUB_OUTPUT;
-        fi
-    - name: Azure CLI login
-      if: ${{ steps.buildAzureCredentials_secret_check.outputs.available == 'true' }}
-      uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43    # v3.0.0
-      with:
-        creds: ${{ inputs.buildAzureCredentials }}
-        enable-AzPSSession: true
     - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/run-scripted-build@main
       id: run_build
       name: Run Build

--- a/actions/run-build-process/action.yml
+++ b/actions/run-build-process/action.yml
@@ -85,7 +85,7 @@ outputs:
 runs:
   using: "composite"  
   steps:
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@main
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
       with:
         azureCredentials: ${{ inputs.buildAzureCredentials }}
         additionalEnvVars: ${{ inputs.buildEnv }}

--- a/actions/run-build-process/action.yml
+++ b/actions/run-build-process/action.yml
@@ -85,7 +85,7 @@ outputs:
 runs:
   using: "composite"  
   steps:
-    - uses: ./actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
+    - uses: ./actions/endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
       with:
         azureCredentials: ${{ inputs.buildAzureCredentials }}
         additionalEnvVars: ${{ inputs.buildEnv }}

--- a/actions/run-build-process/action.yml
+++ b/actions/run-build-process/action.yml
@@ -85,7 +85,7 @@ outputs:
 runs:
   using: "composite"  
   steps:
-    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@main
       with:
         azureCredentials: ${{ inputs.buildAzureCredentials }}
         additionalEnvVars: ${{ inputs.buildEnv }}

--- a/actions/run-build-process/action.yml
+++ b/actions/run-build-process/action.yml
@@ -85,7 +85,7 @@ outputs:
 runs:
   using: "composite"  
   steps:
-    - uses: ./actions/endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
+    - uses: endjin/Endjin.RecommendedPractices.GitHubActions/actions/common-pre-scripted-build@feature/194-post-compile-parallel-job
       with:
         azureCredentials: ${{ inputs.buildAzureCredentials }}
         additionalEnvVars: ${{ inputs.buildEnv }}

--- a/build.ps1
+++ b/build.ps1
@@ -167,3 +167,8 @@ task PostPackage {}
 task PrePublish {}
 task PostPublish {}
 task RunLast {}
+
+# Synopsis: Placeholder task to test the optional postCompile phase in the matrix build
+task postCompile {
+    Write-Build 'Post-Compile job'
+}

--- a/build.ps1
+++ b/build.ps1
@@ -167,8 +167,3 @@ task PostPackage {}
 task PrePublish {}
 task PostPublish {}
 task RunLast {}
-
-# Synopsis: Placeholder task to test the optional postCompile phase in the matrix build
-task postCompile {
-    Write-Build 'Post-Compile job'
-}


### PR DESCRIPTION
## Summary

Adds a new optional post-compile job that runs in parallel with test and package phases, enabling consumers to move heavy post-compile work (e.g. documentation website builds) out of the compile phase.

## Changes

- Added 6 new optional inputs: `postCompilePhaseTasks`, `postCompileRunnerOs`, `postCompilePhaseEnv`, `postCompileArtifactName`, `postCompileArtifactPath`
- Added 1 new optional secret: `postCompilePhaseSecrets`
- Added new `postCompile` job that depends on `compile` and runs in parallel with `test` and `package`
- Updated `publish` job to depend on `postCompile` (skipped jobs are treated as success)
- Adds ability to override the `InvokeBuild` tasks run for each phase of the multi-job workflows

## Backwards Compatibility

Fully backwards-compatible. All new inputs default to empty strings. When `postCompilePhaseTasks` is empty (the default), the `postCompile` job is skipped via its `if` condition, and existing behaviour is unchanged.

## Motivation

In `corvus-dotnet/Corvus.JsonSchema`, the documentation website build (6 Blazor WASM playgrounds + API docs) takes ~13 minutes and currently runs inside the compile phase's `PostBuild` task. This makes compile take 28.6 minutes, blocking all downstream jobs. Moving the website build to a parallel post-compile job reduces the critical path from ~49 to ~36 minutes.

Closes #194