### PR TITLE
Fix issue with missing Pester test results

### DIFF
--- a/.github/workflows/scripted-build-matrix-pipeline.yml
+++ b/.github/workflows/scripted-build-matrix-pipeline.yml
@@ -321,7 +321,7 @@ jobs:
       with:
         # Look for test results produced by Pester, VSTest/MTP & PyTest/Behave
         files: |
-          TestResults.xml
+          *TestResults.xml
           **/test-results*.trx
           **/*-test-results.xml
     - name: Publish Test Results (Windows)
@@ -330,7 +330,7 @@ jobs:
       with:
         # Look for test results produced by Pester, VSTest/MTP & PyTest/Behave
         files: |
-          TestResults.xml
+          *TestResults.xml
           **/test-results*.trx
           **/*-test-results.xml
 

--- a/.github/workflows/scripted-build-pipeline.yml
+++ b/.github/workflows/scripted-build-pipeline.yml
@@ -287,7 +287,7 @@ jobs:
       with:
         # Look for test results produced by Pester, VSTest/MTP & PyTest/Behave
         files: |
-          TestResults.xml
+          *TestResults.xml
           **/test-results*.trx
           **/*-test-results.xml
     - name: Publish Test Results (Windows)
@@ -296,7 +296,7 @@ jobs:
       with:
         # Look for test results produced by Pester, VSTest/MTP & PyTest/Behave
         files: |
-          TestResults.xml
+          *TestResults.xml
           **/test-results*.trx
           **/*-test-results.xml
 

--- a/actions/run-build-process/action.yml
+++ b/actions/run-build-process/action.yml
@@ -191,7 +191,7 @@ runs:
       with:
         # Look for test results produced by Pester, VSTest/MTP & PyTest/Behave
         files: |
-          TestResults.xml
+          *TestResults.xml
           **/test-results*.trx
           **/*-test-results.xml
     - name: Publish Test Results (Windows)
@@ -200,6 +200,6 @@ runs:
       with:
         # Look for test results produced by Pester, VSTest/MTP & PyTest/Behave
         files: |
-          TestResults.xml
+          *TestResults.xml
           **/test-results*.trx
           **/*-test-results.xml


### PR DESCRIPTION
This fixes a glob that was not finding Pester test result files when being surfaced in the GHA build summary.